### PR TITLE
wip: tty: add color support

### DIFF
--- a/src/kernel/main.zig
+++ b/src/kernel/main.zig
@@ -1,7 +1,11 @@
-const TTY = @import("tty.zig").TTY;
+const TTY = @import("tty.zig");
 
 export fn kernel_main() noreturn {
-    var tty = TTY.init(80, 25);
-    tty.print("42\n");
+    var tty = TTY.TTY.init(80, 25);
+    var color: u8 = TTY.vga_entry_color(TTY.ConsoleColors.Red, TTY.ConsoleColors.Black);
+    tty.print("42\nsecond line\n\t\tjust some tabs\nnewlines!!!!\n\n\n\n.\n", color);
+    color = TTY.vga_entry_color(TTY.ConsoleColors.Blue, TTY.ConsoleColors.Black);
+    tty.print("42\nsecond line\n\t\tjust some tabs\nnewlines!!!!\n\n\n\n.\n", color);
+    tty.print("42\nsecond line\n\t\tjust some tabs\nnewlines!!!!\n\n\n\n.\n", null);
     while (true) {}
 }

--- a/src/kernel/tty.zig
+++ b/src/kernel/tty.zig
@@ -1,3 +1,25 @@
+pub const ConsoleColors = enum(u8) {
+    Black = 0,
+    Blue = 1,
+    Green = 2,
+    Cyan = 3,
+    Red = 4,
+    Magenta = 5,
+    Brown = 6,
+    LightGray = 7,
+    DarkGray = 8,
+    LightBlue = 9,
+    LightGreen = 10,
+    LightCyan = 11,
+    LightRed = 12,
+    LightMagenta = 13,
+    LightBrown = 14,
+    White = 15,
+};
+
+pub fn vga_entry_color(fg: ConsoleColors, bg: ConsoleColors) u8 {
+    return @intFromEnum(fg) | (@intFromEnum(bg) << 4);
+}
 
 pub const TTY = struct {
     width: u16,
@@ -5,11 +27,13 @@ pub const TTY = struct {
     _vga: [*]u16 = @ptrFromInt(0xB8000),
     _x: u16 = 0,
     _y: u16 = 0,
+    _terminal_color: u8 = 0,
 
     pub fn init(width: u16, height: u16) TTY {
         return TTY{
             .width = width,
             .height = height,
+            ._terminal_color = vga_entry_color(ConsoleColors.White, ConsoleColors.Black),
         };
     }
 
@@ -17,16 +41,17 @@ pub const TTY = struct {
         self._y = 0;
     }
 
-    fn printChar(self: *TTY, c: u8) void {
+    fn printChar(self: *TTY, c: u8, color: ?u8) void {
+        const final_color: u8 = color orelse self._terminal_color;
         if (c == '\n') {
             self._y += 1;
             self._x = 0;
             if (self._y >= self.height) {
                 self._scroll();
             }
-            return ;
+            return;
         }
-        self._vga[self._y * self.width + self._x] = (0x0f << 8) | @as(u16, c);
+        self._vga[self._y * self.width + self._x] = self.vga_entry(c, final_color);
         self._x += 1;
         if (self._x >= self.width) {
             self._x = 0;
@@ -37,12 +62,20 @@ pub const TTY = struct {
         }
     }
 
-    pub fn print(self: *TTY, msg: [*:0] const u8) void {
+    pub fn print(self: *TTY, msg: [*:0]const u8, color: ?u8) void {
         var idx: usize = 0;
         while (msg[idx] != 0) : (idx += 1)
-            self.printChar(msg[idx]);
+            self.printChar(msg[idx], color);
     }
 
-    pub fn setColor() void {}
+    pub fn setColor(self: *TTY, new_color: u8) void {
+        self._terminal_color = new_color;
+    }
 
+    pub fn vga_entry(self: *TTY, uc: u8, new_color: u8) u16 {
+        _ = self;
+        const c: u16 = new_color;
+
+        return uc | (c << 8);
+    }
 };


### PR DESCRIPTION
tty is now initialized with a default color
of white with black background and can be modified either to have a different value or to change only on each print call.