### PR TITLE
kfs: vmm: Preallocate kernel page tables

### DIFF
--- a/src/arch/x86/mm/vmm.zig
+++ b/src/arch/x86/mm/vmm.zig
@@ -85,11 +85,12 @@ pub const VMM = struct {
     pub fn init(pmm: *PMM) VMM {
         initial_page_dir[1023] = (@intFromPtr(&initial_page_dir) - PAGE_OFFSET)
             | PAGE_PRESENT | PAGE_WRITE;
-        const vmm = VMM{ 
+        var vmm = VMM{ 
             .pmm = pmm,
         };
         initial_page_dir[0] = 0;
         invalidatePage(0);
+        vmm.initKernelSpace();
         return vmm;
     }
 

--- a/src/arch/x86/mm/vmm.zig
+++ b/src/arch/x86/mm/vmm.zig
@@ -231,7 +231,7 @@ pub const VMM = struct {
     }
 
     pub fn initKernelSpace(self: *VMM) void {
-        var count: u32 = 0;
+        const first_pt: [*]u32 = @ptrCast(first_page_table);
         for (KERNEL_START..1023) |idx| { // last one is kept for recursive paging
             if (initial_page_dir[idx] == 0) {
                 const pfn: u32 = self.pmm.allocPage();
@@ -239,7 +239,8 @@ pub const VMM = struct {
                     @panic("Could not allocate memory for kernel space.");
                 }
                 initial_page_dir[idx] = pfn | PAGE_PRESENT | PAGE_WRITE; // Premap page tables
-                count += 1;
+                var pt = first_pt + (0x400 * idx);
+                @memset(pt[0..1024], 0);
             }
         }
     }

--- a/src/debug/mm.zig
+++ b/src/debug/mm.zig
@@ -200,7 +200,8 @@ pub fn printMapped() void {
             if (start != 1) {
                 end = (pd_idx << 22);
                 total += end - start;
-                printMappedArea(start, end, huge_page);
+                if (end > start)
+                    printMappedArea(start, end, huge_page);
                 start = 1;
             }
             continue;
@@ -212,7 +213,8 @@ pub fn printMapped() void {
         } else if (huge_page != pde.huge_page) {
             end = (pd_idx << 22);
             total += end - start;
-            printMappedArea(start, end, huge_page);
+            if (end > start)
+                printMappedArea(start, end, huge_page);
             start = dir_base;
             huge_page = pde.huge_page;
         }
@@ -228,7 +230,7 @@ pub fn printMapped() void {
                     if (start != 1) {
                         end = (pd_idx << 22) | (pt_idx << 12);
                         total += end - start;
-                        if (total > 0)
+                        if (end > start)
                             printMappedArea(start, end, huge_page);
                         start = 1;
                     }

--- a/src/kernel/mm/kmalloc.zig
+++ b/src/kernel/mm/kmalloc.zig
@@ -1,11 +1,15 @@
 const mm = @import("init.zig");
+const krn = @import("../main.zig");
 
 // TODO: Fix Alignment for memery returned to 16
 /// kmalloc - allocate memory
 /// size:
 ///     how many bytes of memory are required.
 pub fn kmalloc(size: u32) u32 {
-    return mm.kheap.alloc(size, true, false) catch 0;
+    krn.logger.INFO("kmalloc: {d}", .{size});
+    const res = mm.kheap.alloc(size, true, false) catch 0;
+    krn.logger.INFO("kmalloc done: {d}", .{size});
+    return res;
 }
 
 pub fn kfree(addr: u32) void {

--- a/src/kernel/mm/kmalloc.zig
+++ b/src/kernel/mm/kmalloc.zig
@@ -1,15 +1,11 @@
 const mm = @import("init.zig");
-const krn = @import("../main.zig");
 
 // TODO: Fix Alignment for memery returned to 16
 /// kmalloc - allocate memory
 /// size:
 ///     how many bytes of memory are required.
 pub fn kmalloc(size: u32) u32 {
-    krn.logger.INFO("kmalloc: {d}", .{size});
-    const res = mm.kheap.alloc(size, true, false) catch 0;
-    krn.logger.INFO("kmalloc done: {d}", .{size});
-    return res;
+    return mm.kheap.alloc(size, true, false) catch 0;
 }
 
 pub fn kfree(addr: u32) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -117,7 +117,7 @@ export fn kernel_main(magic: u32, address: u32) noreturn {
 
     var scrn: screen.Screen = screen.Screen.init(boot_info);
     screen.current_tty = &scrn.tty[0];
-    mm.virt_memory_manager.initKernelSpace();
+
     krn.pit = PIT.init(1000);
     krn.task.initial_task.setup(
         @intFromPtr(&vmm.initial_page_dir),

--- a/src/main.zig
+++ b/src/main.zig
@@ -117,6 +117,7 @@ export fn kernel_main(magic: u32, address: u32) noreturn {
 
     var scrn: screen.Screen = screen.Screen.init(boot_info);
     screen.current_tty = &scrn.tty[0];
+    mm.virt_memory_manager.initKernelSpace();
     krn.pit = PIT.init(1000);
     krn.task.initial_task.setup(
         @intFromPtr(&vmm.initial_page_dir),


### PR DESCRIPTION
- Preallocate kernel space page tables
- Synchronize kernel memory in all processes.

> Originally I wanted to put the call inside `mm/init.zig`. For some reason if I put it there it crashes and
I don't understand why. Lets maybe investigate before merging. Any comments are welcome.