### PR TITLE
syscalls: getpid, getppid

### DIFF
--- a/src/kernel/sched/process.zig
+++ b/src/kernel/sched/process.zig
@@ -38,3 +38,16 @@ pub fn doFork(state: *arch.Regs) i32 {
     );
     return @intCast(child.?.pid);
 }
+
+pub fn getPID() i32 {
+    return @intCast(tsk.current.pid);
+}
+
+pub fn getPPID() i32 {
+    var pid: u32 = 0;
+    if (tsk.current.tree.parent != null) {
+        const p: *tsk.Task = tsk.current.tree.parent.?.entry(tsk.Task, "tree");
+        pid = p.pid;
+    }
+    return @intCast(pid);
+}

--- a/src/kernel/sched/process.zig
+++ b/src/kernel/sched/process.zig
@@ -39,15 +39,33 @@ pub fn doFork(state: *arch.Regs) i32 {
     return @intCast(child.?.pid);
 }
 
-pub fn getPID() i32 {
+pub fn getPID(_: *arch.Regs) i32 {
     return @intCast(tsk.current.pid);
 }
 
-pub fn getPPID() i32 {
+pub fn getPPID(_: *arch.Regs) i32 {
     var pid: u32 = 0;
     if (tsk.current.tree.parent != null) {
         const p: *tsk.Task = tsk.current.tree.parent.?.entry(tsk.Task, "tree");
         pid = p.pid;
     }
     return @intCast(pid);
+}
+
+pub fn getUID(_: *arch.Regs) i32 {
+    return tsk.current.uid;
+}
+
+pub fn setUID(_: *arch.Regs, uid: u32) i32 {
+    tsk.current.uid = uid;
+    return 0;
+}
+
+pub fn getGID(_: *arch.Regs) i32 {
+    return tsk.current.gid;
+}
+
+pub fn setGID(_: *arch.Regs, gid: u32) i32 {
+    tsk.current.gid = gid;
+    return 0;
 }

--- a/src/kernel/syscalls/init.zig
+++ b/src/kernel/syscalls/init.zig
@@ -4,5 +4,9 @@ pub fn init() void {
     register(57, &@import("./fork.zig").fork);
     register(39, &@import("../sched/process.zig").getPID);
     register(62, &@import("./kill.zig").kill);
+    register(102, &@import("../sched/process.zig").getUID);
+    register(104, &@import("../sched/process.zig").getGID);
+    register(105, &@import("../sched/process.zig").setUID);
+    register(106, &@import("../sched/process.zig").setGID);
     register(110, &@import("../sched/process.zig").getPPID);
 }

--- a/src/kernel/syscalls/init.zig
+++ b/src/kernel/syscalls/init.zig
@@ -2,5 +2,7 @@ const register = @import("../irq/syscalls.zig").registerSyscall;
 
 pub fn init() void {
     register(57, &@import("./fork.zig").fork);
+    register(39, &@import("../sched/process.zig").getPID);
     register(62, &@import("./kill.zig").kill);
+    register(110, &@import("../sched/process.zig").getPPID);
 }


### PR DESCRIPTION
## Added syscalls
- getpid 
> returns the process ID (PID) of the calling process.
- getppid
> returns the process ID of the parent of the calling
       process.  This will be either the ID of the process that created
       this process using fork(), or, if that process has already
       terminated, the ID of the process to which this process has been
       reparented
- getuid 
- getgid
 ## Errors
 These functions are always successful.
- setuid
- setgid