### PR TITLE
kfs: signals: SA_RESETHAND

### DIFF
--- a/src/kernel/sched/signals.zig
+++ b/src/kernel/sched/signals.zig
@@ -233,6 +233,10 @@ pub const SigHand = struct {
                     action.mask[0] |= i;
                     self.actions.set(signal, action);
                 }
+                if (action.flags & SA_RESETHAND > 0) {
+                    action.handler.handler = sigDFL;
+                    self.actions.set(signal, action);
+                }
                 return .{.action = action, .signal = i};
             }
         }


### PR DESCRIPTION
Restore the signal action to the default upon entry to the signal handler.