### PR TITLE
Signals

### DIFF
--- a/src/kernel/sched/task.zig
+++ b/src/kernel/sched/task.zig
@@ -95,8 +95,8 @@ pub const Task = struct {
     wakeup_time:    usize           = 0,
 
     // signals
-    sighand:      signal.SigHand        = signal.SigHand.init(),
-    sigmask:        u32                     = 0,
+    sighand:        signal.SigHand       = signal.SigHand.init(),
+    sigmask:        signal.sigset_t      = signal.sigset_t.init(),
 
     // only for kthreads
     threadfn:       ?ThreadHandler       = null,
@@ -159,7 +159,6 @@ pub const Task = struct {
         self.tree.setup();
 
         self.sighand = current.sighand;
-        self.sigmask = 0;
 
         tasks_mutex.lock();
         current.tree.addChild(&self.tree);

--- a/src/kernel/syscalls/sigaction.zig
+++ b/src/kernel/syscalls/sigaction.zig
@@ -29,7 +29,7 @@ pub fn sigreturn(state: *arch.Regs) i32 {
     }
     const saved_regs: *arch.Regs = @ptrFromInt(state.useresp + regs_offset);
     state.* = saved_regs.*;
-    action.sigDelSet(signal);
+    action.mask.sigDelSet(signal);
     tsk.current.sighand.actions.set(signal, action);
     return 0;
 }

--- a/src/kernel/syscalls/sigaction.zig
+++ b/src/kernel/syscalls/sigaction.zig
@@ -13,7 +13,9 @@ pub fn sigaction(_: *arch.Regs, sig: u32, act: ?*signals.Sigaction, oact: ?*sign
     if (oact) |old_act| {
         old_act.* = tsk.current.sighand.actions.get(signal);
     }
-    tsk.current.sighand.actions.set(signal, act.?.*);
+    if (act) |_act| {
+        tsk.current.sighand.actions.set(signal, _act.*);
+    }
     return 0;
 }
 

--- a/userspace/src/main.zig
+++ b/userspace/src/main.zig
@@ -98,13 +98,13 @@ pub export fn main() linksection(".text.main") noreturn {
         _ = os.linux.sigaction(std.c.SIG.USR1, &action, null);
         // action.handler.handler = &empty_func2;
         // action.mask[std.c.SIG.TRAP] = 0;
-        // const action2: std.posix.Sigaction = .{
-        //     .handler = .{ .handler = &empty_func2 },
-        //     .mask = .{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
-        //     // .mask = {@bitCast(std.c.SIG.TRAP)},
-        //     .flags = os.linux.SA.RESTORER,// | os.linux.SA.NODEFER,
-        // };
-        _ = os.linux.sigaction(std.c.SIG.USR2, null, null);
+        const action2: std.posix.Sigaction = .{
+            .handler = .{ .handler = &empty_func2 },
+            .mask = .{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+            // .mask = {@bitCast(std.c.SIG.TRAP)},
+            .flags = os.linux.SA.RESTORER,// | os.linux.SA.NODEFER,
+        };
+        _ = os.linux.sigaction(std.c.SIG.USR2, &action2, null);
         _ = os.linux.kill(3, std.c.SIG.USR1);
         // _ = os.linux.syscall0(os.linux.syscalls.X86.sigpending); // FIXME
         // serial("child after {d}\n", .{ret});

--- a/userspace/src/main.zig
+++ b/userspace/src/main.zig
@@ -98,13 +98,13 @@ pub export fn main() linksection(".text.main") noreturn {
         _ = os.linux.sigaction(std.c.SIG.USR1, &action, null);
         // action.handler.handler = &empty_func2;
         // action.mask[std.c.SIG.TRAP] = 0;
-        const action2: std.posix.Sigaction = .{
-            .handler = .{ .handler = &empty_func2 },
-            .mask = .{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
-            // .mask = {@bitCast(std.c.SIG.TRAP)},
-            .flags = os.linux.SA.RESTORER,// | os.linux.SA.NODEFER,
-        };
-        _ = os.linux.sigaction(std.c.SIG.USR2, &action2, null);
+        // const action2: std.posix.Sigaction = .{
+        //     .handler = .{ .handler = &empty_func2 },
+        //     .mask = .{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+        //     // .mask = {@bitCast(std.c.SIG.TRAP)},
+        //     .flags = os.linux.SA.RESTORER,// | os.linux.SA.NODEFER,
+        // };
+        _ = os.linux.sigaction(std.c.SIG.USR2, null, null);
         _ = os.linux.kill(3, std.c.SIG.USR1);
         // _ = os.linux.syscall0(os.linux.syscalls.X86.sigpending); // FIXME
         // serial("child after {d}\n", .{ret});


### PR DESCRIPTION
Syscalls:
- `sigprocmask`
- `rt_sigprocmask`

Changes:
* Move `sigAddSet`, `sigDelSet` from `Sigaction` to `sigset_t`.

Bug Fixes:
* Fix NULL-ptr deref in `sigaction`

[Linux Implementation](https://elixir.bootlin.com/linux/v6.12.1/source/kernel/signal.c#L4445)