### PR TITLE
kfs: refactor kmalloc.

### DIFF
--- a/src/debug/tests.zig
+++ b/src/debug/tests.zig
@@ -8,20 +8,20 @@ pub fn runTests() void {
 
     printf("Tests are running...\n", .{});
     const size: u32 = 10000;
-    var arr: [size]u32 = .{0} ** size;
+    var arr: [size]?*u32 = .{null} ** size;
     var varr: [size]u32 = .{0} ** size;
     printFreeList();
     while (i < 1) : (i += 1) {
         j = 0;
         while (j < size) : (j += 1) {
-            arr[j] = mm.kmalloc(j);
+            arr[j] = mm.kmalloc(u32);
             varr[j] = mm.vmalloc(j);
         }
         printf("Lets free...\n", .{});
         j = 0;
         while (j < size) : (j += 1) {
-            if (arr[j] != 0)
-                mm.kfree(arr[j]);
+            if (arr[j] != null)
+                mm.kfree(arr[j].?);
             if (varr[j] != 0)
                 mm.vfree(varr[j]);
         }

--- a/src/kernel/mm/init.zig
+++ b/src/kernel/mm/init.zig
@@ -13,6 +13,9 @@ pub const proc_mm = @import("./proc_mm.zig");
 pub const MM = @import("./proc_mm.zig").MM;
 
 pub const kmalloc = @import("./kmalloc.zig").kmalloc;
+pub const kmalloc = @import("./kmalloc.zig").kmalloc;
+pub const kmallocArray = @import("./kmalloc.zig").kmallocArray;
+pub const kfree = @import("./kmalloc.zig").kfree;
 pub const kfree = @import("./kmalloc.zig").kfree;
 pub const ksize = @import("./kmalloc.zig").ksize;
 pub const vmalloc = @import("./vmalloc.zig").vmalloc;

--- a/src/kernel/mm/kmalloc.zig
+++ b/src/kernel/mm/kmalloc.zig
@@ -4,14 +4,24 @@ const mm = @import("init.zig");
 /// kmalloc - allocate memory
 /// size:
 ///     how many bytes of memory are required.
-pub fn kmalloc(size: u32) u32 {
-    return mm.kheap.alloc(size, true, false) catch 0;
+pub fn ksize(addr: *anyopaque) u32 {
+    return mm.kheap.getSize(@intFromPtr(addr));
 }
 
-pub fn kfree(addr: u32) void {
-    mm.kheap.free(addr);
+pub fn kmalloc(comptime T: type) ?*T {
+    const size = @sizeOf(T);
+    const addr = mm.kheap.alloc(size, true, false) catch return null;
+    if (addr == 0) return null;
+    return @ptrFromInt(addr);
 }
 
-pub fn ksize(addr: u32) u32 {
-    return mm.kheap.getSize(addr);
+pub fn kmallocArray(comptime T: type, count: u32) ?[*]T {
+    const size = @sizeOf(T) * count;
+    const addr = mm.kheap.alloc(size, true, false) catch return null;
+    if (addr == 0) return null;
+    return @ptrFromInt(addr);
+}
+
+pub fn kfree(addr: *anyopaque) void {
+    mm.kheap.free(@intFromPtr(addr));
 }

--- a/src/kernel/sched/scheduler.zig
+++ b/src/kernel/sched/scheduler.zig
@@ -51,7 +51,7 @@ fn processTasks() void {
         task.delFromTree();
         task.mm.?.delete();
         kthreadStackFree(task.stack_bottom);
-        km.kfree(@intFromPtr(task));
+        km.kfree(task);
         if (end)
             break;
     }


### PR DESCRIPTION
Previously kmalloc returned a u32 that we had to manually cast to the desired pointer. Now malloc takes comptime type and returns optional pointer to type. Introduce kmallocArray that allocates [*] T of count * sizeof(T) size.

Fixes error in doFork that would return memory allocated as process kernel stack to the heap.