### PR TITLE
kfs: fork: proc

### DIFF
--- a/src/kernel/fs/proc/inode.zig
+++ b/src/kernel/fs/proc/inode.zig
@@ -125,8 +125,9 @@ pub const ProcInode = struct {
         const sb: *fs.SuperBlock = if (base.sb) |_s| _s else return kernel.errors.PosixError.EINVAL;
         if (!base.mode.isDir())
             return error.NotDirectory;
-        if (!base.mode.canWrite(base.uid, base.gid))
-            return error.Access;
+
+        // We are the kernel we can have access to this directory
+        // we don't need to check. This should happen only for userspace
 
         // Lookup if file already exists.
         _ = base.ops.lookup(parent, name) catch {

--- a/src/kernel/syscalls/open.zig
+++ b/src/kernel/syscalls/open.zig
@@ -25,6 +25,18 @@ pub fn do_open(
     target_path.stepInto(name) catch {
         if (flags & fs.file.O_CREAT != 0) {
             new_mode.type = kernel.fs.S_IFREG;
+            if (
+                !target_path.dentry.inode.mode.canExecute(
+                    target_path.dentry.inode.uid,
+                    target_path.dentry.inode.gid
+                )
+                or !target_path.dentry.inode.mode.canWrite(
+                    target_path.dentry.inode.uid,
+                    target_path.dentry.inode.gid
+                )
+            ) {
+                return errors.EACCES;
+            }
             const new_dentry = parent_inode.ops.create(
                 parent_inode,
                 name,


### PR DESCRIPTION
Bug:
- File creation during fork returns EACCESS
- We have already added this child to tree and we don't remove it
- We return error freeing the childs memory and file descriptors but the child will be scheduled.

Fix:
- The kernel should be able to create any files it wants without restrictions
- Syscalls should evaluate permissions before calling the fs callback (same permissions apply globaly for directories)
to write you need `w+x`.
- Open should check permissions before creation like `mkdir` already does