### PR TITLE
kfs: exit: fix exit code.

### DIFF
--- a/src/kernel/sched/signals.zig
+++ b/src/kernel/sched/signals.zig
@@ -440,7 +440,7 @@ fn defaultHandler(signal: Signal, regs: *arch.Regs) *arch.Regs {
         .SIGWINCH => {},
         else => {
             arch.cpu.enableInterrupts();
-            _ = krn.exit.exit(128 + @intFromEnum(signal)) catch {};
+            _ = krn.exit.doExit((128 + @intFromEnum(signal)) & 0x7f) catch {};
             unreachable();
             return krn.sched.schedule(regs);
         }

--- a/src/kernel/syscalls/exit.zig
+++ b/src/kernel/syscalls/exit.zig
@@ -5,7 +5,7 @@ const signals = @import("../sched/signals.zig");
 const kernel = @import("../main.zig");
 const errors = @import("./error-codes.zig").PosixError;
 
-pub fn exit(error_code: i32) !u32 {
+pub fn doExit(error_code: i32) !u32 {
     if (tsk.current == &tsk.initial_task) return errors.EINVAL;
     const files: *kernel.fs.TaskFiles = tsk.current.files;
     var it = files.map.iterator(.{.direction = .forward, .kind = .set});
@@ -42,4 +42,8 @@ pub fn exit(error_code: i32) !u32 {
     kernel.task.tasks_lock.unlock_irq_enable(lock_state);
     sched.reschedule();
     return 0;
+}
+
+pub fn exit(error_code: i32) !u32 {
+    return try doExit((error_code & 0xff) << 8);
 }

--- a/src/kernel/syscalls/wait.zig
+++ b/src/kernel/syscalls/wait.zig
@@ -68,7 +68,7 @@ const WaitStates = struct {
         if (task.state == .ZOMBIE)
             return task.result;
         if (task.state == .INTERRUPTIBLE_SLEEP)
-            return (@as(i32, @intFromEnum(krn.signals.Signal.SIGSTOP)) << 8) | 0x7f;
+            return task.result;
         // TODO: other cases
         return 0xffff;
     }


### PR DESCRIPTION
traditional Unix/POSIX exit status semantics:

- bits 0–6   : terminating signal number (0 if exited normally)
- bit 7      : core dump flag
- bits 8–15  : exit code (valid only for normal exit)
- bits 16–31 : reserved

**Normal exit**:
    status = (exit_code & 0xff) << 8

**Signal termination**:
    status = signal_number & 0x7f
    status |= 0x80 if core dumped (not supported)

Adds **doExit** wrapper than can be called from kernelspace with correct status layout and calls it in exit placing the exit code in the correct location.