### PR TITLE
Cmdline fix

### DIFF
--- a/src/kernel/fs/dev/inode.zig
+++ b/src/kernel/fs/dev/inode.zig
@@ -136,8 +136,12 @@ pub const DevInode = struct {
         if (_dentry.inode.mode.isDir())
             return kernel.errors.PosixError.EISDIR;
 
-        if (_dentry.tree.hasChildren() or _dentry.ref.getValue() > 2)
+        fs.dcache_lock.lock();
+        if (_dentry.tree.hasChildren() or _dentry.ref.getValue() > 2) {
+            fs.dcache_lock.unlock();
             return kernel.errors.PosixError.EBUSY;
+        }
+        fs.dcache_lock.unlock();
 
         _dentry.inode.links -= 1;
         _dentry.release();

--- a/src/kernel/fs/proc/inode.zig
+++ b/src/kernel/fs/proc/inode.zig
@@ -83,13 +83,21 @@ pub const ProcInode = struct {
     }
 
     fn rmdir(current: *fs.DEntry, parent: *fs.DEntry) !void {
-        _ = if (current.inode.sb) |_s| _s else return kernel.errors.PosixError.EINVAL;
-        if (current.tree.hasChildren())
+        _ = if (current.inode.sb) |_s| _s else
+            return kernel.errors.PosixError.EINVAL;
+        fs.dcache_lock.lock();
+        if (current.tree.hasChildren()) {
+            fs.dcache_lock.unlock();
             return kernel.errors.PosixError.ENOTEMPTY;
-        if (current.ref.getValue() > 2)
+        }
+        if (current.ref.getValue() > 2) {
+            fs.dcache_lock.unlock();
             return kernel.errors.PosixError.EBUSY;
+        }
+        fs.dcache_lock.unlock();
 
         parent.inode.links -= 1;
+        current.inode.links = 0;
         current.release();
         current.release();
     }
@@ -100,8 +108,12 @@ pub const ProcInode = struct {
         if (_dentry.inode.mode.isDir())
             return kernel.errors.PosixError.EISDIR;
 
-        if (_dentry.ref.getValue() > 2)
+        fs.dcache_lock.lock();
+        if (_dentry.ref.getValue() > 2) {
+            fs.dcache_lock.unlock();
             return kernel.errors.PosixError.EBUSY;
+        }
+        fs.dcache_lock.unlock();
 
         _dentry.inode.links -= 1;
         _dentry.release();

--- a/src/kernel/fs/proc/task_info.zig
+++ b/src/kernel/fs/proc/task_info.zig
@@ -133,33 +133,27 @@ pub const stat_file_ops = kernel.fs.FileOps{
     .close = close,
 };
 
-fn cmdline_read(file: *kernel.fs.File, buff: [*]u8, size: usize) !usize {
-    const proc_inode = file.inode.getImpl(inode.ProcInode, "base");
+fn cmdline_open(file: *kernel.fs.File, ino: *kernel.fs.Inode) !void {
+    const proc_inode = ino.getImpl(inode.ProcInode, "base");
     const task = proc_inode.task orelse {
         @panic("Should not happen");
     };
+    file.data = null;
     const mm = task.mm orelse
-        return 0;
+        return;
     if (mm.arg_start == 0 or mm.arg_end <= mm.arg_start)
-        return 0;
+        return;
     const args = try mm.accessTaskVM(mm.arg_start, mm.arg_end - mm.arg_start);
-    defer kernel.mm.kfree(args.ptr);
+    errdefer kernel.mm.kfree(args.ptr);
 
-    if (file.pos >= args.len)
-        return 0;
-    var to_read = size;
-    if (file.pos + to_read > args.len)
-        to_read = args.len - file.pos;
-    @memcpy(buff[0..to_read], args[file.pos..file.pos + to_read]);
-    file.pos += to_read;
-    return to_read;
+    try generic_ops.assignSlice(file, args);
 }
 
 pub const cmdline_file_ops = kernel.fs.FileOps{
-    .open = open,
-    .read = cmdline_read,
-    .write = write,
-    .close = close,
+    .open = cmdline_open,
+    .read = generic_ops.generic_read,
+    .write = generic_ops.generic_write,
+    .close = generic_ops.generic_close,
 };
 
 fn kernel_stack_trace_read(file: *kernel.fs.File, buff: [*]u8, size: usize) !usize {

--- a/src/kernel/fs/proc/task_info.zig
+++ b/src/kernel/fs/proc/task_info.zig
@@ -140,34 +140,19 @@ fn cmdline_read(file: *kernel.fs.File, buff: [*]u8, size: usize) !usize {
     };
     const mm = task.mm orelse
         return 0;
-    if (mm.arg_start == 0)
+    if (mm.arg_start == 0 or mm.arg_end <= mm.arg_start)
         return 0;
     const args = try mm.accessTaskVM(mm.arg_start, mm.arg_end - mm.arg_start);
     defer kernel.mm.kfree(args.ptr);
 
-    var written: usize = 0;
-    var args_off: usize = 0;
-    while (args_off < args.len) {
-        const arg_ptr: [*:0]const u8 = @ptrCast(&args.ptr[args_off]);
-        const arg: []const u8 = std.mem.span(arg_ptr);
-        if (args_off + arg.len > file.pos) {
-            const arg_pos = file.pos - args_off;
-            var to_write = args_off + arg.len - file.pos;
-            if (written + to_write > size)
-                to_write = size - written;
-            @memcpy(
-                buff[written..written + to_write],
-                arg[arg_pos..arg_pos + to_write]
-            );
-            written += to_write;
-            file.pos += to_write;
-            if (written >= size)
-                return written;
-        }
-        file.pos += 1;
-        args_off += arg.len + 1;
-    }
-    return written;
+    if (file.pos >= args.len)
+        return 0;
+    var to_read = size;
+    if (file.pos + to_read > args.len)
+        to_read = args.len - file.pos;
+    @memcpy(buff[0..to_read], args[file.pos..file.pos + to_read]);
+    file.pos += to_read;
+    return to_read;
 }
 
 pub const cmdline_file_ops = kernel.fs.FileOps{

--- a/src/kernel/fs/sys/inode.zig
+++ b/src/kernel/fs/sys/inode.zig
@@ -117,8 +117,12 @@ pub const SysInode = struct {
         if (_dentry.inode.mode.isDir())
             return kernel.errors.PosixError.EISDIR;
 
-        if (_dentry.tree.hasChildren() or _dentry.ref.getValue() > 2)
+        fs.dcache_lock.lock();
+        if (_dentry.tree.hasChildren() or _dentry.ref.getValue() > 2) {
+            fs.dcache_lock.unlock();
             return kernel.errors.PosixError.EBUSY;
+        }
+        fs.dcache_lock.unlock();
 
         _dentry.inode.links -= 1;
         _dentry.release();


### PR DESCRIPTION
Fixed cmdline file - zeroes (\0) in args string should be preserved, not removed.
Fixed integer overflow bug in cmdline_read.
Fixed unlink / rmdir race condition leading to refcount underflow for vfs inodes.
Fixed memory leak in procfs - directory inodes where never freed in rmdir because inode.links was never set to 0.
