### PR TITLE
Vdso

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -57,7 +57,7 @@ pub fn build(b: *std.Build) !void {
 
     arch_mod.addImport("debug", debug_mod);
     arch_mod.addImport("kernel", kernel_mod);
-    
+
     debug_mod.addImport("arch", arch_mod);
     debug_mod.addImport("drivers", drivers_mod);
     debug_mod.addImport("kernel", kernel_mod);
@@ -72,7 +72,44 @@ pub fn build(b: *std.Build) !void {
     modules_mod.addImport("debug", debug_mod);
     modules_mod.addImport("drivers", drivers_mod);
 
-    var target: std.Target.Query = .{ 
+    var vdso_target: std.Target.Query = .{
+        .cpu_arch = arch,
+        .os_tag = .linux,
+        .abi = .none
+    };
+    const VdsoFeatures = std.Target.x86.Feature;
+    vdso_target.cpu_features_sub.addFeature(@intFromEnum(VdsoFeatures.avx));
+    vdso_target.cpu_features_sub.addFeature(@intFromEnum(VdsoFeatures.avx2));
+    vdso_target.cpu_features_sub.addFeature(@intFromEnum(VdsoFeatures.sse));
+    vdso_target.cpu_features_sub.addFeature(@intFromEnum(VdsoFeatures.sse2));
+    vdso_target.cpu_features_add.addFeature(@intFromEnum(VdsoFeatures.soft_float));
+
+    const vdso = b.addLibrary(.{
+        .linkage = .dynamic,
+        .name = "vdso",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/vdso/vdso_time.zig"),
+            .target = b.resolveTargetQuery(vdso_target),
+            .optimize = .ReleaseSmall,
+            .pic = true,
+            .strip = true,
+        }),
+    });
+    vdso.setLinkerScript(b.path("src/vdso/vdso.ld"));
+    vdso.root_module.stack_protector = false;
+    vdso.root_module.stack_check = false;
+    vdso.root_module.red_zone = false;
+
+    const vdso_wf = b.addWriteFiles();
+    _ = vdso_wf.addCopyFile(vdso.getEmittedBin(), "vdso.so");
+    const vdso_wrapper = vdso_wf.add("vdso_image.zig",
+        \\pub const data = @embedFile("vdso.so");
+    );
+    kernel_mod.addAnonymousImport("vdso_image", .{
+        .root_source_file = vdso_wrapper,
+    });
+
+    var target: std.Target.Query = .{
         .cpu_arch = arch,
         .os_tag = .freestanding,
         .abi = .none

--- a/docs/docs/vdso.md
+++ b/docs/docs/vdso.md
@@ -1,0 +1,215 @@
+# vDSO (virtual Dynamic Shared Object)
+
+The vDSO is a small shared library that the kernel maps into every userspace
+process. It allows certain system calls — specifically time-related ones — to
+be executed entirely in userspace without the cost of a context switch into
+the kernel.
+
+On x86, every `int $0x80` or `sysenter` transition involves saving registers,
+switching privilege levels, and flushing pipeline state. For frequently called
+functions like `clock_gettime`, this overhead dominates the actual work.
+The vDSO eliminates it by placing both the data and the code to read it
+directly in the process's address space.
+
+## Architecture
+
+The vDSO consists of two components mapped into every process:
+
+| Component | Size | Permissions | Purpose |
+|:----------|:-----|:------------|:--------|
+| **vvar page** | 1 page (4 KiB) | User: read-only, Kernel: read-write | Shared time data updated by the kernel |
+| **vDSO code page** | 1 page (4 KiB) | User: read-only | ELF shared library with `__vdso_clock_gettime` |
+
+The vvar page holds a `VdsoData` struct that the kernel writes to on every
+timer tick. The vDSO code page contains a position-independent ELF shared
+library that reads from the vvar page to service time queries.
+
+```
+Process virtual address space (top):
+
+  0xBFFE0000  ┌──────────────────┐
+              │   User stack     │  30 pages, RW
+              │   (grows down)   │
+  0xBFFFE000  ├──────────────────┤
+              │   vvar page      │  1 page, RO (shared physical page)
+  0xBFFFF000  ├──────────────────┤
+              │   vDSO code      │  1 page, RO (ELF with __vdso_clock_gettime)
+  0xC0000000  └──────────────────┘
+              │   Kernel space   │
+```
+
+### Why two separate pages?
+
+The vvar and vDSO code live in separate pages for security:
+
+- The **vvar page** is mapped read-only for userspace but the kernel holds a
+  separate read-write mapping to the same physical page. This allows the kernel
+  to update time data without giving userspace write access.
+- The **vDSO code page** is read-only and contains executable code. Keeping data
+  and code separate follows the W^X (write xor execute) principle.
+
+## Shared Data: VdsoData
+
+The vvar page contains a single `VdsoData` struct at offset 0:
+
+```zig
+pub const VdsoData = extern struct {
+    seq: u32,            // seqlock counter
+    monotonic_sec: i32,
+    monotonic_nsec: i32,
+    realtime_sec: i64,
+    realtime_nsec: i32,
+    _pad: i32,
+};
+```
+
+The kernel writes to this struct from the timer interrupt handler on every tick.
+Userspace reads from it without any syscall.
+
+### Seqlock Protocol
+
+The `seq` field implements a seqlock — a lightweight synchronization mechanism
+optimized for the single-writer, multiple-reader pattern:
+
+**Kernel (writer):**
+
+1. Increment `seq` to an odd value (signals: update in progress)
+2. Memory barrier
+3. Write time data
+4. Memory barrier
+5. Increment `seq` to an even value (signals: update complete)
+
+**Userspace (reader):**
+
+1. Read `seq` — spin while odd (writer is active)
+2. Memory barrier
+3. Read time data
+4. Memory barrier
+5. Read `seq` again — if changed, data was torn, retry from step 1
+
+This guarantees userspace always reads a consistent snapshot without any locks
+or atomic operations beyond simple loads.
+
+```zig
+// Kernel side (timer interrupt)
+vvar_data.seq +%= 1;           // odd: update started
+asm volatile ("" ::: .{ .memory = true });
+vvar_data.monotonic_sec = ...;
+vvar_data.monotonic_nsec = ...;
+asm volatile ("" ::: .{ .memory = true });
+vvar_data.seq +%= 1;           // even: update complete
+```
+
+```zig
+// Userspace side (vDSO code)
+while (true) {
+    var seq1 = vvar.seq;
+    while (seq1 & 1 != 0) seq1 = vvar.seq;  // spin while odd
+    // read time fields ...
+    if (seq1 == vvar.seq) return 0;          // consistent read
+}
+```
+
+## Build Pipeline
+
+The vDSO is compiled as a separate ELF shared library and embedded into the
+kernel binary at build time:
+
+1. **Compile** `src/vdso/vdso_time.zig` as a PIC shared library targeting
+   `x86-linux-none` with `ReleaseSmall` optimization
+2. **Link** with `src/vdso/vdso.ld` which strips unnecessary sections (`.got`,
+   `.bss`, `.eh_frame`) to minimize size
+3. **Embed** the resulting `vdso.so` into the kernel module via a generated
+   Zig wrapper that uses `@embedFile`
+4. At runtime the kernel copies the embedded ELF bytes into userspace pages
+
+The vDSO ELF is typically under 1 KiB and fits in a single page.
+
+### Position Independence
+
+The vDSO code must work at any virtual address since the mapping location can
+vary. On x86-32 there is no RIP-relative addressing, so the vDSO uses a
+classic `call/pop` idiom to determine its own program counter at runtime:
+
+```zig
+inline fn getVvarData() *const volatile VdsoData {
+    const pc = asm volatile (
+        \\call 1f
+        \\1: pop %[ret]
+        : [ret] "=r" (-> u32),
+    );
+    const vvar_addr = (pc & 0xFFFFF000) - 0x1000;
+    return @ptrFromInt(vvar_addr);
+}
+```
+
+This avoids any GOT (Global Offset Table) dependency. The vvar page is always
+one page before the vDSO code page, so the address is computed by page-aligning
+the current PC and subtracting `0x1000`.
+
+!!! note "Why not use an extern symbol?"
+    x86-32 PIC code routes extern symbol accesses through the GOT,
+    which requires relocation processing by a dynamic linker.
+    Since the kernel maps the vDSO by raw `@memcpy` without applying
+    relocations, GOT entries remain uninitialized (zero), causing null pointer
+    dereferences. The PC-relative approach eliminates this entirely.
+
+## Kernel Integration
+
+### Initialization
+
+During boot, `vdso.init()` is called after memory management is set up:
+
+1. Allocate one physical page for the vvar data
+2. Map it into kernel virtual address space as read-write
+3. Zero the page
+4. allocated vdso.len / PAGE_SIZE pages, and copy the content of the vdso
+   libray to those pages, padding the rest with 0.
+
+After CMOS initialization, `cmos.ready` is set to true to enable
+realtime clock updates in the vvar data.
+
+### Timer Update
+
+On every timer interrupt, `vdso.update()` writes the current
+monotonic and realtime timestamps to the vvar page using the seqlock protocol.
+
+### Process Mapping
+
+When a new process is created via `execve`, `prepareBinary()` maps both the
+vvar and vDSO code pages into the process address space:
+
+1. **vvar page**: A new VMA is created and the shared physical page is mapped
+   user-read-only. All processes share the same physical page so they all
+   see the same time data.
+2. **vDSO code page**: A new physical page is allocated, the embedded ELF is
+   copied in, and the page is then made read-only.
+3. **Auxiliary vector**: `AT_SYSINFO_EHDR` (value 33) is added pointing to
+   the vDSO ELF header address.
+
+### Fork Behavior
+
+On `fork()`, the vvar VMA is duplicated like any other shared mapping —
+`dupArea` maps the underlying physical frame to the vvar, vdso address.
+
+## Userspace Discovery
+
+C libraries (musl, glibc) automatically discover and use the vDSO:
+
+1. During `_start`, the C runtime walks the auxiliary vector on the stack
+2. It reads `AT_SYSINFO_EHDR` to find the vDSO ELF header
+3. It parses the ELF dynamic section to find `DT_SYMTAB`, `DT_STRTAB`, and
+   `DT_HASH`
+4. It looks up `__vdso_clock_gettime` in the symbol table
+5. If found, `clock_gettime()` calls the vDSO function directly instead of
+   issuing a syscall
+
+This is transparent to application code — calling `clock_gettime()` in C
+automatically uses the vDSO path when available.
+
+## Supported Clocks
+
+| Clock ID | Constant | Description |
+|:---------|:---------|:------------|
+| 0 | `CLOCK_REALTIME` | Wall clock time from CMOS |
+| 1 | `CLOCK_MONOTONIC` | Time since kernel boot |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -10,6 +10,8 @@ Nav:
     - locking.md
   Signals:
     - Signals.md
+  vDSO:
+    - vdso.md
   LibC:
     - Signals.md
 

--- a/src/arch/x86/mm/vmm.zig
+++ b/src/arch/x86/mm/vmm.zig
@@ -226,8 +226,10 @@ pub const VMM = struct {
         pt = @ptrCast(first_page_table);
         pt += (0x400 * pd_idx);
         if (pt[pt_idx] != 0) {
-            krn.logger.ERROR("PD idx {d}\n", .{pd_idx});
-            @panic("PT is not 0\n");
+            const phys = pt[pt_idx] >> 12 << 12;
+            if (phys != physical_addr) {
+                @panic("Page already mapped to different physical address");
+            }
         }
         const new_flags = @as(u12, @bitCast(flags));
         pt[pt_idx] = physical_addr | new_flags;

--- a/src/drivers/cmos.zig
+++ b/src/drivers/cmos.zig
@@ -80,7 +80,7 @@ pub const CMOS = struct {
         const epoch_day = epoch_secs.getEpochDay();
         const year_day = epoch_day.calculateYearDay();
         const month_day = year_day.calculateMonthDay();
-        
+
         const sec = day_secs.getSecondsIntoMinute();
         const mins = day_secs.getMinutesIntoHour();
         const hours = day_secs.getHoursIntoDay();
@@ -112,7 +112,7 @@ pub const CMOS = struct {
         }
         if (status & 0x04 != 0)
             bin_mode = true;
-    
+
         if (self.curr_time[5] != year) {
             writeByte(0x09, if (bin_mode) @intCast(year) else binToBCD(@intCast(year)));
             self.curr_time[5] = @intCast(year);
@@ -208,8 +208,10 @@ pub const CMOS = struct {
 };
 
 var cmos: CMOS = undefined;
+pub var ready: bool = false;
 
 pub fn init() void {
     cmos = CMOS.init();
     krn.cmos = &cmos;
+    ready = true;
 }

--- a/src/drivers/pit.zig
+++ b/src/drivers/pit.zig
@@ -2,6 +2,7 @@ const io = @import("arch").io;
 const krn = @import("kernel");
 
 pub var HZ: u32 = 1000;
+pub var ns_in_one_tick: u32 = undefined;
 
 pub const PIT = struct {
     clock_freq: u32 = 1193182,
@@ -38,14 +39,18 @@ pub const PIT = struct {
         return @truncate(reload_value);
     }
 
-    pub fn setFrequency(self: *PIT, frequency: u32) void {
+    pub fn setFrequency(self: *PIT, _frequency: u32) void {
+        var frequency = _frequency;
+        if (frequency < 1000) {
+            frequency = 1000;
+        } else if (frequency > 1_000_000) {
+            frequency = 1_000_000;
+        }
         HZ = frequency;
+        ns_in_one_tick = 1_000_000 / frequency;
         const divider = self.calculateDivider(frequency);
         io.outb(0x43, 0b00110100);
         io.outb(0x40, @truncate(divider & 0xFF));
         io.outb(0x40, @truncate(divider >> 8));
     }
-
-
 };
-

--- a/src/kernel/main.zig
+++ b/src/kernel/main.zig
@@ -31,6 +31,7 @@ pub const sleep = @import("./sched/task.zig").sleep;
 pub const Mutex = @import("./sched/mutex.zig").Mutex;
 pub const Spinlock = @import("./sched/spinlock.zig").Spinlock;
 pub const userspace = @import("./userspace/userspace.zig");
+pub const vdso = @import("./vdso.zig");
 pub const signals = @import("./sched/signals.zig");
 
 pub const getSecondsFromStart = @import("./time/jiffies.zig").getSecondsFromStart;
@@ -48,6 +49,7 @@ pub var logger: Logger = undefined;
 pub var boot_info: multiboot.Multiboot = undefined;
 pub var scr: screen.Screen = undefined;
 pub var cmos: *drv.cmos.CMOS = undefined;
+pub var cmos_ready = &drv.cmos.ready;
 
 pub const proc_mm = @import("./mm/proc_mm.zig");
 pub const fs = @import("fs/fs.zig");

--- a/src/kernel/time/jiffies.zig
+++ b/src/kernel/time/jiffies.zig
@@ -1,5 +1,6 @@
 const drivers = @import("drivers");
 const krn = @import("../main.zig");
+const vdso = @import("../vdso.zig");
 pub var jiffies: u32 = 0;
 pub var cpu_user_ticks: u64 = 0;
 pub var cpu_system_ticks: u64 = 0;
@@ -24,6 +25,8 @@ pub fn timerHandler() void {
         cpu_system_ticks += 1;
         current.stime += 1;
     }
+
+    vdso.update();
 
     if (jiffies % drivers.pit.HZ == 0) {
         // Every second

--- a/src/kernel/time/jiffies.zig
+++ b/src/kernel/time/jiffies.zig
@@ -12,8 +12,13 @@ pub const CpuTicks = struct {
     idle: u64,
 };
 
+var fb_counter: u8 = 0;
+var hz_counter: u32 = 0;
+
 pub fn timerHandler() void {
     jiffies += 1;
+    fb_counter += 1;
+    hz_counter += 1;
 
     const current = krn.task.current;
     if (current == &krn.task.initial_task) {
@@ -26,14 +31,19 @@ pub fn timerHandler() void {
         current.stime += 1;
     }
 
-    vdso.update();
-
-    if (jiffies % drivers.pit.HZ == 0) {
+    if (hz_counter == drivers.pit.HZ) {
+        hz_counter = 0;
         // Every second
         krn.cmos.incSec(krn.cmos);
+        vdso.updateTime(1, 0);
+    } else {
+        vdso.updateTime(0, @intCast(drivers.pit.ns_in_one_tick));
     }
-    if (jiffies % 30 == 0 and krn.screen.framebuffer.has_dirty)
-        drivers.framebuffer.render_queue.wakeUpOne();
+    if (fb_counter == 30) {
+        fb_counter = 0;
+        if (krn.screen.framebuffer.has_dirty)
+            drivers.framebuffer.render_queue.wakeUpOne();
+    }
 }
 
 pub fn getSecondsFromStart() u32 {

--- a/src/kernel/userspace/userspace.zig
+++ b/src/kernel/userspace/userspace.zig
@@ -48,6 +48,9 @@ const AT_PHNUM = 5; // number of program headers
 const AT_PAGESZ = 6;
 const AT_BASE = 7;  // load base for PIE
 const AT_ENTRY = 9; // entry point address
+const AT_SYSINFO_EHDR = 33; // vDSO ELF header address
+
+const vdso = @import("../vdso.zig");
 
 pub const ElfValidationError = error {
     InvalidMagic,
@@ -253,7 +256,9 @@ pub fn prepareBinary(userspace: []const u8, argv: []const []const u8, envp: []co
             heap_start = seg_end;
     }
     const stack_size: usize = stack_pages * arch.PAGE_SIZE;
-    var stack_bottom: usize = krn.mm.PAGE_OFFSET - stack_pages * arch.PAGE_SIZE;
+    const vdso_code_pages = vdso.imagePages();
+    const vdso_total_pages = 1 + vdso_code_pages; // vvar + code
+    var stack_bottom: usize = krn.mm.PAGE_OFFSET - stack_pages * arch.PAGE_SIZE - vdso_total_pages * arch.PAGE_SIZE;
     stack_bottom = krn.task.current.mm.?.mmap_area(
         stack_bottom,
         stack_size,
@@ -268,7 +273,15 @@ pub fn prepareBinary(userspace: []const u8, argv: []const []const u8, envp: []co
     const stack_ptr: [*]u8 = @ptrFromInt(stack_bottom);
     @memset(stack_ptr[0..stack_size], 0);
 
-    var aux_buf: [8]AuxEntry = undefined;
+    // Map vDSO and vvar pages above the stack
+    const vdso_base = stack_bottom + stack_size; // vvar page
+    const vdso_ehdr_addr = vdso_base + arch.PAGE_SIZE; // vDSO ELF code
+    vdso.mapIntoUserspace(krn.task.current.mm.?, vdso_base) catch {
+        krn.task.current.mm.?.releaseMappings();
+        return krn.errors.PosixError.ENOMEM;
+    };
+
+    var aux_buf: [10]AuxEntry = undefined;
     var aux_count: usize = 0;
     if (is_pie) {
         aux_buf[aux_count] = .{ .key = AT_PHDR, .val = load_base + ehdr.e_phoff };
@@ -282,6 +295,8 @@ pub fn prepareBinary(userspace: []const u8, argv: []const []const u8, envp: []co
         aux_buf[aux_count] = .{ .key = AT_BASE, .val = load_base };
         aux_count += 1;
     }
+    aux_buf[aux_count] = .{ .key = AT_SYSINFO_EHDR, .val = vdso_ehdr_addr };
+    aux_count += 1;
     aux_buf[aux_count] = .{ .key = AT_PAGESZ, .val = krn.mm.PAGE_SIZE };
     aux_count += 1;
     aux_buf[aux_count] = .{ .key = AT_NULL, .val = 0 };

--- a/src/kernel/vdso.zig
+++ b/src/kernel/vdso.zig
@@ -81,24 +81,25 @@ pub fn init() void {
     krn.logger.INFO("vDSO: vvar phys=0x{X:0>8} kern_virt=0x{X:0>8} image_size={d} code_pages={d}", .{
         vvar_page, vvar_virt, vdso_image.len, num_code_pages,
     });
-}
-
-pub fn update() void {
-    if (vvar_phys == 0) return;
-
-    vvar_data.seq +%= 1;
-    asm volatile ("" ::: .{ .memory = true });
-
-    const monotonic = krn.getTimeFromStart();
-    vvar_data.monotonic_sec = monotonic.tv_sec;
-    vvar_data.monotonic_nsec = monotonic.tv_nsec;
-
     if (krn.cmos_ready.*) {
+        const monotonic = krn.getTimeFromStart();
         const realtime_sec: u64 = krn.cmos.toUnixSeconds(krn.cmos);
         vvar_data.realtime_sec = @intCast(realtime_sec);
         vvar_data.realtime_nsec = monotonic.tv_nsec;
     }
+}
 
+pub inline fn updateTime(sec: i32, nsec: i32) void {
+    if (vvar_phys == 0) return;
+
+    vvar_data.seq +%= 1;
+    asm volatile ("" ::: .{ .memory = true });
+    vvar_data.monotonic_sec += sec;
+    vvar_data.monotonic_nsec = 
+        if (nsec == 0) 0
+        else vvar_data.monotonic_nsec + nsec;
+    vvar_data.realtime_sec += sec;
+    vvar_data.realtime_nsec = vvar_data.monotonic_nsec;
     asm volatile ("" ::: .{ .memory = true });
     vvar_data.seq +%= 1;
 }

--- a/src/kernel/vdso.zig
+++ b/src/kernel/vdso.zig
@@ -1,0 +1,174 @@
+const arch = @import("arch");
+const krn = @import("./main.zig");
+
+pub const VdsoData = extern struct {
+    seq: u32 = 0,
+    monotonic_sec: i32 = 0,
+    monotonic_nsec: i32 = 0,
+    realtime_sec: i64 = 0,
+    realtime_nsec: i32 = 0,
+    _pad: i32 = 0,
+};
+
+const vdso_image = @import("vdso_image").data;
+
+pub var vvar_phys: usize = 0;
+var vvar_data: *volatile VdsoData = undefined;
+
+var code_phys: [max_code_pages]usize = [_]usize{0} ** max_code_pages;
+var code_page_count: usize = 0;
+const max_code_pages = 4; // This can be increase if needed
+
+pub fn init() void {
+    const num_code_pages = imagePages();
+    if (num_code_pages > max_code_pages)
+        @panic("vdso: image too large");
+
+    const lock_state = krn.mm.mem_lock.lock_irq_disable();
+    const vvar_page = krn.mm.virt_memory_manager.pmm.allocPage();
+    if (vvar_page == 0)
+        @panic("vdso: cannot allocate vvar page");
+
+    const vvar_virt = krn.mm.virt_memory_manager.findFreeSpace(
+        1, krn.mm.PAGE_OFFSET, 0xFFFFF000, false,
+    );
+    if (vvar_virt == 0xFFFFFFFF)
+        @panic("vdso: cannot find kernel virtual space for vvar");
+
+    krn.mm.virt_memory_manager.mapPage(vvar_virt, vvar_page, .{
+        .present = true,
+        .writable = true,
+        .user = false,
+    });
+
+    const code_virt = krn.mm.virt_memory_manager.findFreeSpace(
+        @intCast(num_code_pages), krn.mm.PAGE_OFFSET, 0xFFFFF000, false,
+    );
+    if (code_virt == 0xFFFFFFFF)
+        @panic("vdso: cannot find kernel virtual space for code");
+
+    for (0..num_code_pages) |i| {
+        const phys = krn.mm.virt_memory_manager.pmm.allocPage();
+        if (phys == 0)
+            @panic("vdso: cannot allocate code page");
+        code_phys[i] = phys;
+        krn.mm.virt_memory_manager.mapPage(
+            @intCast(code_virt + i * arch.PAGE_SIZE),
+            phys,
+            .{ .present = true, .writable = true, .user = false },
+        );
+    }
+
+    krn.mm.mem_lock.unlock_irq_enable(lock_state);
+
+    code_page_count = num_code_pages;
+    vvar_phys = vvar_page;
+    vvar_data = @ptrFromInt(vvar_virt);
+
+    // Initialize the variables to 0
+    const zero_ptr: [*]u8 = @ptrFromInt(vvar_virt);
+    @memset(zero_ptr[0..arch.PAGE_SIZE], 0);
+
+    const dest: [*]u8 = @ptrFromInt(code_virt);
+    @memcpy(dest[0..vdso_image.len], vdso_image);
+
+    // Set padding to 0. We could maybe in the future do that
+    // at compile time but for now its not worth the effort.
+    if (vdso_image.len < num_code_pages * arch.PAGE_SIZE) {
+        @memset(dest[vdso_image.len .. num_code_pages * arch.PAGE_SIZE], 0);
+    }
+
+    krn.logger.INFO("vDSO: vvar phys=0x{X:0>8} kern_virt=0x{X:0>8} image_size={d} code_pages={d}", .{
+        vvar_page, vvar_virt, vdso_image.len, num_code_pages,
+    });
+}
+
+pub fn update() void {
+    if (vvar_phys == 0) return;
+
+    vvar_data.seq +%= 1;
+    asm volatile ("" ::: .{ .memory = true });
+
+    const monotonic = krn.getTimeFromStart();
+    vvar_data.monotonic_sec = monotonic.tv_sec;
+    vvar_data.monotonic_nsec = monotonic.tv_nsec;
+
+    if (krn.cmos_ready.*) {
+        const realtime_sec: u64 = krn.cmos.toUnixSeconds(krn.cmos);
+        vvar_data.realtime_sec = @intCast(realtime_sec);
+        vvar_data.realtime_nsec = monotonic.tv_nsec;
+    }
+
+    asm volatile ("" ::: .{ .memory = true });
+    vvar_data.seq +%= 1;
+}
+
+pub fn imageSize() usize {
+    return vdso_image.len;
+}
+
+pub fn imagePages() usize {
+    const size = vdso_image.len;
+    return (size + arch.PAGE_SIZE - 1) / arch.PAGE_SIZE;
+}
+
+pub fn mapIntoUserspace(mm: *krn.mm.MM, vdso_base: usize) !void {
+    const vvar_addr = vdso_base;
+    const vdso_code_addr = vdso_base + arch.PAGE_SIZE;
+
+    // Map the shared vvar page (read-only for userspace)
+    const vvar_vma = krn.mm.VMA.allocEmpty() orelse return error.OutOfMemory;
+    vvar_vma.start = vvar_addr;
+    vvar_vma.end = vvar_addr + arch.PAGE_SIZE;
+    vvar_vma.mm = mm;
+    vvar_vma.flags = krn.mm.MAP{ .TYPE = .SHARED, .ANONYMOUS = true };
+    vvar_vma.prot = krn.mm.PROT_READ;
+    vvar_vma.file = null;
+    vvar_vma.offset = 0;
+
+    {
+        const lock_state = krn.mm.mem_lock.lock_irq_disable();
+        krn.mm.virt_memory_manager.mapPage(@intCast(vvar_addr), @intCast(vvar_phys), .{
+            .present = true,
+            .writable = false,
+            .user = true,
+        });
+        krn.mm.mem_lock.unlock_irq_enable(lock_state);
+    }
+
+    if (mm.vmas) |head| {
+        head.list.addTail(&vvar_vma.list);
+    } else {
+        vvar_vma.list.setup();
+        mm.vmas = vvar_vma;
+    }
+
+    // Map the shared vDSO code pages (read-only for userspace)
+    const code_vma = krn.mm.VMA.allocEmpty() orelse return error.OutOfMemory;
+    code_vma.start = vdso_code_addr;
+    code_vma.end = vdso_code_addr + code_page_count * arch.PAGE_SIZE;
+    code_vma.mm = mm;
+    code_vma.flags = krn.mm.MAP{ .TYPE = .SHARED, .ANONYMOUS = true };
+    code_vma.prot = krn.mm.PROT_READ;
+    code_vma.file = null;
+    code_vma.offset = 0;
+
+    {
+        const lock_state = krn.mm.mem_lock.lock_irq_disable();
+        for (0..code_page_count) |i| {
+            krn.mm.virt_memory_manager.mapPage(
+                @intCast(vdso_code_addr + i * arch.PAGE_SIZE),
+                @intCast(code_phys[i]),
+                .{ .present = true, .writable = false, .user = true },
+            );
+        }
+        krn.mm.mem_lock.unlock_irq_enable(lock_state);
+    }
+
+    if (mm.vmas) |head| {
+        head.list.addTail(&code_vma.list);
+    } else {
+        code_vma.list.setup();
+        mm.vmas = code_vma;
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -182,6 +182,8 @@ export fn kernel_main(magic: u32, address: u32) noreturn {
     krn.serial.print("[INIT]: IDT done\n");
     mm.mmInit(&krn.boot_info);
     krn.serial.print("[INIT]: Memory done\n");
+    krn.vdso.init();
+    krn.serial.print("[INIT]: vDSO done\n");
     krn.task.initMultitasking();
     krn.serial.print("[INIT]: Multitasking done\n");
     fpu.setTaskSwitched();

--- a/src/main.zig
+++ b/src/main.zig
@@ -182,8 +182,6 @@ export fn kernel_main(magic: u32, address: u32) noreturn {
     krn.serial.print("[INIT]: IDT done\n");
     mm.mmInit(&krn.boot_info);
     krn.serial.print("[INIT]: Memory done\n");
-    krn.vdso.init();
-    krn.serial.print("[INIT]: vDSO done\n");
     krn.task.initMultitasking();
     krn.serial.print("[INIT]: Multitasking done\n");
     fpu.setTaskSwitched();
@@ -201,6 +199,8 @@ export fn kernel_main(magic: u32, address: u32) noreturn {
     krn.serial.print("[INIT]: Syscalls done\n");
     drv.cmos.init();
     krn.serial.print("[INIT]: CMOS done\n");
+    krn.vdso.init(); // Should be initialized after cmos
+    krn.serial.print("[INIT]: vDSO done\n");
 
     // FS
     krn.fs.init();

--- a/src/vdso/vdso.ld
+++ b/src/vdso/vdso.ld
@@ -1,0 +1,26 @@
+SECTIONS
+{
+    . = SIZEOF_HEADERS;
+
+    .text : { *(.text .text.*) } :text
+    .rodata : { *(.rodata .rodata.*) } :text
+    .data : { *(.data .data.*) } :text
+    .dynamic : { *(.dynamic) } :text :dynamic
+
+    /DISCARD/ : {
+        *(.comment)
+        *(.eh_frame)
+        *(.eh_frame_hdr)
+        *(.note.*)
+        *(.bss)
+        *(.bss.*)
+        *(.got)
+        *(.got.plt)
+    }
+}
+
+PHDRS
+{
+    text PT_LOAD FLAGS(5);
+    dynamic PT_DYNAMIC FLAGS(4);
+}

--- a/src/vdso/vdso_time.zig
+++ b/src/vdso/vdso_time.zig
@@ -1,0 +1,97 @@
+const VdsoData = extern struct {
+    seq: u32,
+    monotonic_sec: i32,
+    monotonic_nsec: i32,
+    realtime_sec: i64,
+    realtime_nsec: i32,
+    _pad: i32,
+};
+
+const kernel_timespec = extern struct {
+    tv_sec: i32,
+    tv_nsec: i32,
+};
+
+const kernel_timespec64 = extern struct {
+    tv_sec: i64,
+    tv_nsec: i64,
+};
+
+const CLOCK_REALTIME: u32 = 0;
+const CLOCK_MONOTONIC: u32 = 1;
+const PAGE_MASK: u32 = 0xFFFFF000;
+const EINVAL: i32 = 22;
+
+inline fn getVvarData() *const volatile VdsoData {
+    // Get current PC
+    const pc = asm volatile (
+        \\call 1f
+        \\1: pop %[ret]
+        : [ret] "=r" (-> u32),
+    );
+    // Page-align to get the vDSO code page base, then subtract one page for vvar
+    const vvar_addr = (pc & PAGE_MASK) - 0x1000;
+    return @ptrFromInt(vvar_addr);
+}
+
+export fn __vdso_clock_gettime(clock_id: u32, tp: ?*kernel_timespec) i32 {
+    const out = tp orelse return -EINVAL;
+    const vvar = getVvarData();
+
+    while (true) {
+        var seq1 = vvar.seq;
+        while (seq1 & 1 != 0) {
+            seq1 = vvar.seq;
+        }
+        asm volatile ("" ::: .{ .memory = true });
+
+        switch (clock_id) {
+            CLOCK_MONOTONIC => {
+                out.tv_sec = vvar.monotonic_sec;
+                out.tv_nsec = vvar.monotonic_nsec;
+            },
+            CLOCK_REALTIME => {
+                out.tv_sec = @truncate(vvar.realtime_sec);
+                out.tv_nsec = vvar.realtime_nsec;
+            },
+            else => return -1,
+        }
+
+        asm volatile ("" ::: .{ .memory = true });
+        const seq2 = vvar.seq;
+        if (seq1 == seq2) {
+            return 0;
+        }
+    }
+}
+
+export fn __vdso_clock_gettime64(clock_id: u32, tp: ?*kernel_timespec64) i32 {
+    const out = tp orelse return -EINVAL;
+    const vvar = getVvarData();
+
+    while (true) {
+        var seq1 = vvar.seq;
+        while (seq1 & 1 != 0) {
+            seq1 = vvar.seq;
+        }
+        asm volatile ("" ::: .{ .memory = true });
+
+        switch (clock_id) {
+            CLOCK_MONOTONIC => {
+                out.tv_sec = vvar.monotonic_sec;
+                out.tv_nsec = vvar.monotonic_nsec;
+            },
+            CLOCK_REALTIME => {
+                out.tv_sec = @truncate(vvar.realtime_sec);
+                out.tv_nsec = vvar.realtime_nsec;
+            },
+            else => return -1,
+        }
+
+        asm volatile ("" ::: .{ .memory = true });
+        const seq2 = vvar.seq;
+        if (seq1 == seq2) {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION

## Summary

Adds a **vDSO** so time queries can run in userspace without a syscall on every `clock_gettime`. Only time-related vDSO symbols are supported.

- **vvar page**: shared read-only in userspace, kernel-writable; holds `VdsoData` with a **seqlock** and monotonic/realtime fields.
- **vDSO code**: small PIC ELF with `__vdso_clock_gettime` / `__vdso_clock_gettime64`; built separately, **embedded** into the kernel; **PC-relative** access to vvar.
- **Boot**: one physical vvar page and one set of code pages allocated and filled in **`vdso.init()`**; each exec only **maps** them.
- **Exec layout**: stack, then vvar, then code; stack region is shifted down so it does not overlap; **`AT_SYSINFO_EHDR`** points at the vDSO ELF.
- **Fork**: vvar and code VMAs are **SHARED** so children do not get a stale COW copy of vvar.
- **Timer**: **`vdso.update()`** from the timer tick; realtime from CMOS only after CMOS is ready.