### PR TITLE
Reschedule

### DIFF
--- a/src/arch/x86/idt.zig
+++ b/src/arch/x86/idt.zig
@@ -58,50 +58,6 @@ pub fn goUserspace() void {
     );
 }
 
-pub fn switchTo(from: *tsk.Task, to: *tsk.Task, state: *Regs) *Regs {
-    @setRuntimeSafety(false);
-    from.regs = state.*;
-    from.regs.setStackPointer(@intFromPtr(state));
-    if (from.save_fpu_state) {
-        if (from.fpu_state) |fpu_state| {
-            fpu.saveFPUState(fpu_state);
-            fpu.setTaskSwitched();
-        }
-        from.save_fpu_state = false;
-    }
-    tsk.current = to;
-    if (to == &tsk.initial_task) {
-        gdt.tss.esp0 = @intFromPtr(&stack_top);
-    } else {
-        gdt.tss.esp0 = to.stack_bottom + krn.STACK_SIZE; // this needs fixing
-    }
-    vmm.switchToVAS(to.mm.?.vas);
-    var access: u8 = 0;
-    access |= 0x10; // S=1
-    access |= 0x60; // DPL=3
-    access |= 0x02; // data, writable
-    access |= 0x80; // P=1  (force present, don’t trust user)
-
-    var gran: u8 = 0;
-    gran |= 0x80; // G=1 (pages)
-    gran |= 0x40; // D=1 (32-bit)
-    gran |= 0x10; // AVL=1 (harmless)
-    gdt.gdtSetEntry(
-        gdt.GDT_TLS0_INDEX,
-        to.tls,
-        to.limit,
-        access,
-        gran,
-    );
-    const sel: u16 = @intCast((gdt.GDT_TLS0_INDEX << 3) | 0x3);
-    asm volatile (
-        "mov %[_sel], %gs"
-        :: [_sel]"r"(sel)
-        : .{ .memory = true}
-    );
-    return @ptrFromInt(to.regs.getStackPointer());
-}
-
 pub export fn exceptionHandler(state: *Regs) callconv(.c) *Regs {
     if (krn.irq.handlers[state.int_no] != null) {
         const handler: *const ExceptionHandler = @ptrCast(krn.irq.handlers[state.int_no].?);
@@ -113,7 +69,6 @@ pub export fn exceptionHandler(state: *Regs) callconv(.c) *Regs {
 pub export fn irqHandler(state: *Regs) callconv(.c) *Regs {
     @setRuntimeSafety(false);
     const orig_eax = state.eax;
-    var new_state: *Regs = state;
     if (krn.irq.handlers[state.int_no] != null) {
         if (state.int_no == SYSCALL_INTERRUPT) {
             const handler: *const SyscallHandler = @ptrCast(krn.irq.handlers[state.int_no].?);
@@ -128,21 +83,12 @@ pub export fn irqHandler(state: *Regs) callconv(.c) *Regs {
     if (state.int_no >= 40) {
         io.outb(0xA0, 0x20);
     }
-    if (state.int_no == TIMER_INTERRUPT) {
-        new_state = krn.sched.schedule(state);
-    }
+    if (state.int_no == TIMER_INTERRUPT)
+        krn.sched.schedule();
 
-    if (new_state != state) {
-        // schedule() switched to a different task. We're still on the old
-        // task's kernel stack, but tsk.current is the new task. Process
-        // signals on the new task's kernel stack so that any kernel-mode
-        // work (doExit, archReschedule, etc.) uses the correct stack.
-        new_state = processSignalsOnNewStack(new_state, orig_eax);
-    } else {
-        new_state = processSignalsHelper(new_state, orig_eax);
-    }
+    _ = processSignalsHelper(state, orig_eax);
 
-    return new_state;
+    return state;
 }
 
 pub export fn processSignalsHelper(regs: *Regs, orig_eax: i32) callconv(.c) *Regs {
@@ -153,30 +99,6 @@ pub export fn processSignalsHelper(regs: *Regs, orig_eax: i32) callconv(.c) *Reg
         return signals.processSignals(regs, &ucontext);
     }
     return regs;
-}
-
-/// Switches ESP to the new task's kernel stack (at the saved Regs frame),
-/// calls processSignalsHelper there, then restores the original ESP.
-/// If processSignalsHelper never returns (doExit → reschedule), the old
-/// stack is abandoned — the old task resumes from its own saved state.
-noinline fn processSignalsOnNewStack(new_state: *Regs, orig_eax: i32) *Regs {
-    @setRuntimeSafety(false);
-    return @ptrFromInt(asm volatile (
-        \\ mov %%esp, %%ecx
-        \\ mov %%edi, %%esp
-        \\ push %%ecx
-        \\ push %%ebx
-        \\ push %%esi
-        \\ lea processSignalsHelper, %%eax
-        \\ call *%%eax
-        \\ add $8, %%esp
-        \\ pop %%esp
-        : [ret] "={eax}" (-> usize),
-        : [new_esp] "{edi}" (@intFromPtr(new_state)),
-          [regs] "{esi}" (@intFromPtr(new_state)),
-          [orig_eax] "{ebx}" (@as(u32, @bitCast(orig_eax))),
-        : .{ .memory = true }
-    ));
 }
 
 const ErrorCodes = std.EnumMap(krn.exceptions.Exceptions, bool).init(.{

--- a/src/arch/x86/main.zig
+++ b/src/arch/x86/main.zig
@@ -9,8 +9,13 @@ pub const fpu = @import("fpu.zig");
 pub const Regs = @import("system/cpu.zig").Regs;
 pub const cpu = @import("system/cpu.zig");
 pub const cpuid = @import("system/cpuid.zig");
-pub const archReschedule = @import("system/cpu.zig").archReschedule;
+pub const saveFlagsAndCli = @import("system/cpu.zig").saveFlagsAndCli;
+pub const restoreFlags = @import("system/cpu.zig").restoreFlags;
 pub const setupStack = @import("system/cpu.zig").setupStack;
+pub const sw = @import("system/switch.zig");
+pub const contextSwitch = sw.contextSwitch;
+pub const setupSwitchFrame = sw.setupSwitchFrame;
+pub const retFromFork = sw.retFromFork;
 pub const syscalls = @import("syscalls/syscalls.zig");
 
 pub const pageAlign = @import("mm/pmm.zig").pageAlign;

--- a/src/arch/x86/system/cpu.zig
+++ b/src/arch/x86/system/cpu.zig
@@ -139,48 +139,24 @@ pub fn areIntEnabled() bool {
     return false;
 }
 
-pub inline fn archReschedule() void {
-    asm volatile(
+/// Saves EFLAGS and disables interrupts.
+pub inline fn saveFlagsAndCli() u32 {
+    return asm volatile (
         \\ pushf
-        \\ pop %%eax            # Pop into EAX
-        \\ test $0x200, %%eax   # Test bit 9 (IF)
-        \\ jz 1f      # Jump if interrupts are disabled
-        \\ pushf
+        \\ pop %[flags]
         \\ cli
-        \\ push %[code_seg]     # CS (kernel code segment)
-        \\ push $1f
-        \\ push $0
-        \\ push $16
-        \\ pusha
-        \\ push %%ds
-        \\ push %%es
-        \\ push %%fs
-        \\ push %%gs
-        \\ mov %[data_seg], %%ax
-        \\ mov %%ax, %%ds
-        \\ mov %%ax, %%es
-        \\ mov %%ax, %%fs
-        \\ mov %%ax, %%gs
-        \\ mov %%esp, %%eax
-        \\ push %%eax
-        \\ lea schedule, %%eax
-        \\ call *%%eax
-        \\ add $4, %%esp
-        \\ mov %%eax, %%esp
-        \\ pop %%gs
-        \\ pop %%fs
-        \\ pop %%es
-        \\ pop %%ds
-        \\ popa
-        \\ add $8, %%esp
-        \\ iret
-        \\ 1:
-        \\ nop
-        \\
-        :
-        : [code_seg] "i" (KERNEL_CODE_SEGMENT),
-          [data_seg] "i" (KERNEL_DATA_SEGMENT)
-        : .{ .memory = true, .eax = true }
+        : [flags] "=r" (-> u32),
+        :: .{ .memory = true, .cc = true }
+    );
+}
+
+/// Restores EFLAGS passed from flags.
+pub inline fn restoreFlags(flags: u32) void {
+    asm volatile (
+        \\ push %[flags]
+        \\ popf
+        :: [flags] "r" (flags)
+        : .{ .memory = true, .cc = true }
     );
 }
 

--- a/src/arch/x86/system/switch.zig
+++ b/src/arch/x86/system/switch.zig
@@ -1,0 +1,128 @@
+const tsk = @import("kernel").task;
+const krn = @import("kernel");
+const gdt = @import("../gdt.zig");
+const vmm = @import("../mm/vmm.zig");
+const fpu = @import("../fpu.zig");
+
+extern const stack_top: u32;
+
+// switch_to(prev_save: *u32, next_sp: u32)
+//
+// prev_save: pointer to the per_task kernel_esp
+// next_sp: The stack pointer to change to
+//
+// Pushes prev's callee-saved registers, stores the resulting esp into
+// *prev_save (parking prev), loads next_sp into esp (the synchronous stack
+// switch), restores next's callee-saved registers and `ret`s into wherever
+// next last parked. cdecl: after the four pushes, ret addr is at 16(%esp),
+// prev_save at 20(%esp), next_sp at 24(%esp).
+//
+// Stack layout:
+// [esp + 0]  = edi          ← just pushed
+// [esp + 4]  = esi
+// [esp + 8]  = ebx
+// [esp + 12] = ebp
+// [esp + 16] = return address
+// [esp + 20] = prev_save  (arg0)
+// [esp + 24] = next_sp    (arg1)
+comptime {
+    asm (
+        \\.global switch_to
+        \\.type switch_to, @function
+        \\switch_to:
+        \\  push %ebp
+        \\  push %ebx
+        \\  push %esi
+        \\  push %edi
+        \\  movl 20(%esp), %eax
+        \\  movl %esp, (%eax)
+        \\  movl 24(%esp), %esp
+        \\  pop %edi
+        \\  pop %esi
+        \\  pop %ebx
+        \\  pop %ebp
+        \\  ret
+    );
+}
+
+extern fn switch_to(prev_save: *u32, next_sp: u32) callconv(.c) void;
+
+// Bottom part of Generate IRQ stub to return from freshly forked
+// process
+pub fn retFromFork() callconv(.naked) noreturn {
+    asm volatile (
+        \\ pop %gs
+        \\ pop %fs
+        \\ pop %es
+        \\ pop %ds
+        \\ popa
+        \\ add $8, %esp
+        \\ iret
+    );
+}
+
+/// Builds the initial switch frame on a new task's kernel stack so the first
+/// switch_to lands on `trampoline`.
+///
+/// Layout written, from low to high address:
+///   [kesp+0]  edi = 0
+///   [kesp+4]  esi = 0
+///   [kesp+8]  ebx = 0
+///   [kesp+12] ebp = 0
+///   [kesp+16] return address = trampoline
+/// Returns kesp, which the caller stores in task.kernel_esp.
+pub fn setupSwitchFrame(esp_after_ret: usize, trampoline: usize) u32 {
+    const kesp: usize = esp_after_ret - 5 * @sizeOf(u32);
+    const frame: [*]u32 = @ptrFromInt(kesp);
+    frame[0] = 0; // edi
+    frame[1] = 0; // esi
+    frame[2] = 0; // ebx
+    frame[3] = 0; // ebp
+    frame[4] = @intCast(trampoline); // ret addr
+    return @intCast(kesp);
+}
+
+/// Must be called with interrupts disabled.
+pub fn contextSwitch(prev: *tsk.Task, next: *tsk.Task) void {
+    @setRuntimeSafety(false);
+    if (prev.save_fpu_state) {
+        if (prev.fpu_state) |fpu_state| {
+            fpu.saveFPUState(fpu_state);
+            fpu.setTaskSwitched();
+        }
+        prev.save_fpu_state = false;
+    }
+    tsk.current = next;
+    if (next == &tsk.initial_task) {
+        gdt.tss.esp0 = @intFromPtr(&stack_top);
+    } else {
+        gdt.tss.esp0 = next.stack_bottom + krn.STACK_SIZE;
+    }
+    vmm.switchToVAS(next.mm.?.vas);
+
+    var access: u8 = 0;
+    access |= 0x10; // S=1
+    access |= 0x60; // DPL=3
+    access |= 0x02; // data, writable
+    access |= 0x80; // P=1  (force present, don't trust user)
+
+    var gran: u8 = 0;
+    gran |= 0x80; // G=1 (pages)
+    gran |= 0x40; // D=1 (32-bit)
+    gran |= 0x10; // AVL=1 (harmless)
+    gdt.gdtSetEntry(
+        gdt.GDT_TLS0_INDEX,
+        next.tls,
+        next.limit,
+        access,
+        gran,
+    );
+    const sel: u16 = @intCast((gdt.GDT_TLS0_INDEX << 3) | 0x3);
+    asm volatile (
+        "mov %[_sel], %gs"
+        :: [_sel]"r"(sel)
+        : .{ .memory = true}
+    );
+
+    switch_to(&prev.kernel_esp, next.kernel_esp);
+}

--- a/src/kernel/fs/dev/super.zig
+++ b/src/kernel/fs/dev/super.zig
@@ -51,7 +51,7 @@ pub const DevSuper = struct {
     fn destroyInode(self: *fs.SuperBlock, base: *fs.Inode) !void {
         base.ref.put();
         while (!base.ref.isFree()) {
-            arch.archReschedule();
+            kernel.sched.reschedule();
         }
         _ = self.inode_map.remove(base.i_no);
         const dev_inode = base.getImpl(DevInode, "base");

--- a/src/kernel/fs/ext2/super.zig
+++ b/src/kernel/fs/ext2/super.zig
@@ -635,7 +635,7 @@ pub const Ext2Super = struct {
 
         base.ref.put();
         while (!base.ref.isFree()) {
-            arch.archReschedule();
+            kernel.sched.reschedule();
         }
 
         // Inode Bitmap

--- a/src/kernel/fs/proc/super.zig
+++ b/src/kernel/fs/proc/super.zig
@@ -44,7 +44,7 @@ pub const ProcSuper = struct {
     fn destroyInode(self: *fs.SuperBlock, base: *fs.Inode) !void {
         base.ref.put();
         while (!base.ref.isFree()) {
-            arch.archReschedule();
+            kernel.sched.reschedule();
         }
         _ = self.inode_map.remove(base.i_no);
         const proc_inode = base.getImpl(ProcInode, "base");

--- a/src/kernel/fs/sys/super.zig
+++ b/src/kernel/fs/sys/super.zig
@@ -4,6 +4,7 @@ const SysInode = @import("inode.zig").SysInode;
 const std = @import("std");
 const device = @import("drivers").device;
 const arch = @import("arch");
+const krn = @import("../../main.zig");
 
 const SYSFS_MAGIC = 0x62656572;
 
@@ -51,7 +52,7 @@ pub const SysSuper = struct {
     fn destroyInode(self: *fs.SuperBlock, base: *fs.Inode) !void {
         base.ref.put();
         while (!base.ref.isFree()) {
-            arch.archReschedule();
+            krn.sched.reschedule();
         }
         _ = self.inode_map.remove(base.i_no);
         const sys_inode = base.getImpl(SysInode, "base");

--- a/src/kernel/sched/kthread.zig
+++ b/src/kernel/sched/kthread.zig
@@ -14,6 +14,7 @@ pub const STACK_SIZE: u32 = (STACK_PAGES - 1) * PAGE_SIZE;
 pub const ThreadHandler = *const fn (arg: ?*const anyopaque) i32;
 
 fn threadWrapper() callconv(.c) noreturn {
+    arch.cpu.enableInterrupts();
     tsk.current.result = tsk.current.threadfn.?(tsk.current.arg);
     tsk.current.finish(false);
     if (tsk.current.mm) |_mm|
@@ -71,12 +72,9 @@ pub fn kthreadCreate(f: ThreadHandler, arg: ?*const anyopaque, name: [*:0]const 
             km.kfree(task);
             return error.MemoryAllocation;
         }
-        const stack_top: usize = arch.setupStack(
+        task.kernel_esp = arch.setupSwitchFrame(
             stack + STACK_SIZE,
             @intFromPtr(&threadWrapper),
-            0,
-            arch.idt.KERNEL_CODE_SEGMENT,
-            arch.idt.KERNEL_DATA_SEGMENT,
         );
         task.threadfn = f;
         task.arg = arg;
@@ -88,7 +86,7 @@ pub fn kthreadCreate(f: ThreadHandler, arg: ?*const anyopaque, name: [*:0]const 
         task.tgid = task.pid;
         task.initSelf(
             .RUNNING,
-            stack_top,
+            stack + STACK_SIZE,
             stack,
             0,
             0,

--- a/src/kernel/sched/process.zig
+++ b/src/kernel/sched/process.zig
@@ -73,6 +73,9 @@ pub fn doFork() !u32 {
     var child_regs: *arch.Regs = @ptrFromInt(stack_top);
     child_regs.* = parent_regs.*;
     child_regs.eax = 0;
+    // The switch frame sits below the trap frame so the first switch_to lands
+    // on ret_from_fork, which irets to userspace.
+    child.kernel_esp = arch.setupSwitchFrame(stack_top, @intFromPtr(&arch.retFromFork));
     child.tls = krn.task.current.tls;
     child.limit = krn.task.current.limit;
     child.initSelf(

--- a/src/kernel/sched/scheduler.zig
+++ b/src/kernel/sched/scheduler.zig
@@ -5,7 +5,6 @@ const km = @import("../mm/kmalloc.zig");
 const kthreadStackFree = @import("./kthread.zig").kthreadStackFree;
 const STACK_SIZE = @import("./kthread.zig").STACK_SIZE;
 const currentMs = @import("../time/jiffies.zig").currentMs;
-const archReschedule = @import("arch").archReschedule;
 const signals = @import("./signals.zig");
 const std = @import("std");
 const gdt = @import("arch").gdt;
@@ -69,13 +68,20 @@ fn findNextTask() *tsk.Task {
     return &tsk.initial_task;
 }
 
-pub export fn schedule(state: *Regs) *Regs {
+pub fn schedule() void {
     if (tsk.initial_task.list.isEmpty())
-        return state;
+        return;
+    const flags = arch.cpu.saveFlagsAndCli();
+    defer arch.cpu.restoreFlags(flags);
     processTasks();
-    return arch.idt.switchTo(tsk.current, findNextTask(), state);
+    const prev = tsk.current;
+    const next = findNextTask();
+    if (prev != next)
+        arch.contextSwitch(prev, next);
 }
 
 pub fn reschedule() void {
-    archReschedule();
+    if (!arch.cpu.areIntEnabled())
+        return;
+    schedule();
 }

--- a/src/kernel/sched/signals.zig
+++ b/src/kernel/sched/signals.zig
@@ -460,7 +460,8 @@ fn defaultHandler(signal: Signal, regs: *arch.Regs) *arch.Regs {
             task.wakeup_time = 0;
             task.state = .INTERRUPTIBLE_SLEEP;
             task.wakeupParent(false);
-            return krn.sched.schedule(regs);
+            krn.sched.reschedule();
+            return regs;
         },
         .SIGCONT => {},
         .SIGCHLD,
@@ -471,7 +472,8 @@ fn defaultHandler(signal: Signal, regs: *arch.Regs) *arch.Regs {
             _ = krn.exit.doExitGroup((
                 128 + @as(i32, @intCast(signal.toPosix()))
             ) & 0x7f) catch {};
-            return krn.sched.schedule(regs);
+            krn.sched.reschedule();
+            return regs;
         }
     }
     return regs;

--- a/src/kernel/sched/task.zig
+++ b/src/kernel/sched/task.zig
@@ -89,6 +89,7 @@ pub const Task = struct {
     ctty:           ?*krn.fs.File   = null,
     stack_bottom:   usize,
     state:          TaskState       = TaskState.RUNNING,
+    kernel_esp:     u32             = 0,
     regs:           Regs            = Regs.init(),
     tls:            u32             = 0,
     limit:          u32             = 0,
@@ -156,6 +157,7 @@ pub const Task = struct {
             .vfork_wq = null,
             .group_leader = undefined,
             .thread_data = null,
+            .kernel_esp = 0
         };
     }
 
@@ -194,6 +196,7 @@ pub const Task = struct {
         self.should_stop = false;
         self.vfork_wq = null;
         self.sigpending = krn.signals.SigPending.init();
+        self.kernel_esp = 0;
     }
 
     pub fn setName(self: *Task, name: []const u8) void {

--- a/src/kernel/syscalls/clone.zig
+++ b/src/kernel/syscalls/clone.zig
@@ -192,6 +192,9 @@ pub fn clone(
     var child_regs: *arch.Regs = @ptrFromInt(stack_top);
     child_regs.* = parent_regs.*;
     child_regs.eax = 0;
+    // See doFork: the switch frame sits below the trap frame so the first
+    // switch_to lands on ret_from_fork, which irets to userspace.
+    child.kernel_esp = arch.setupSwitchFrame(stack_top, @intFromPtr(&arch.retFromFork));
 
     if (child_stack != 0) {
         // FIXME: properly map this address to userspace stack

--- a/src/kernel/syscalls/exit.zig
+++ b/src/kernel/syscalls/exit.zig
@@ -1,5 +1,4 @@
 const tsk = @import("../sched/task.zig");
-const arch = @import("arch");
 const sched = @import("../sched/scheduler.zig");
 const signals = @import("../sched/signals.zig");
 const kernel = @import("../main.zig");
@@ -43,7 +42,7 @@ pub fn doExit(error_code: i32) !u32 {
     kernel.fs.procfs.deleteProcess(kernel.task.current);
     kernel.task.current.refcount.put();
     while (kernel.task.current.refcount.getValue() > 1)
-        arch.archReschedule();
+        kernel.sched.reschedule();
 
     tsk.current.releaseSharedResources();
     const lock_state = kernel.task.tasks_lock.lock_irq_disable();

--- a/types/types.zig
+++ b/types/types.zig
@@ -601,6 +601,9 @@ pub const arch = struct {
 
     };
 
+    pub const sw = struct {
+    };
+
     pub const syscalls = struct {
         pub const thread = struct {
             pub const UserDesc = extern struct {
@@ -833,6 +836,7 @@ pub const kernel = struct {
             ctty : ?*kernel.fs.file.File= null,
             stack_bottom : u32,
             state : kernel.task.TaskState,
+            kernel_esp : u32= 0,
             regs : arch.Regs,
             tls : u32= 0,
             limit : u32= 0,
@@ -876,7 +880,6 @@ pub const kernel = struct {
     };
 
     pub const sched = struct {
-        pub extern fn schedule(*arch.Regs)*arch.Regs;
     };
 
     pub const Mutex = struct {
@@ -930,39 +933,38 @@ pub const kernel = struct {
         };
 
         pub const Signal = enum(u8) {
-            EMPTY = 0,
-            SIGHUP = 1,
-            SIGINT = 2,
-            SIGQUIT = 3,
-            SIGILL = 4,
-            SIGTRAP = 5,
-            SIGABRT = 6,
-            SIGBUS = 7,
-            SIGFPE = 8,
-            SIGKILL = 9,
-            SIGUSR1 = 10,
-            SIGSEGV = 11,
-            SIGUSR2 = 12,
-            SIGPIPE = 13,
-            SIGALRM = 14,
-            SIGTERM = 15,
-            SIGSTKFLT = 16,
-            SIGCHLD = 17,
-            SIGCONT = 18,
-            SIGSTOP = 19,
-            SIGTSTP = 20,
-            SIGTTIN = 21,
-            SIGTTOU = 22,
-            SIGURG = 23,
-            SIGXCPU = 24,
-            SIGXFSZ = 25,
-            SIGVTALRM = 26,
-            SIGPROF = 27,
-            SIGWINCH = 28,
-            SIGIO = 29,
-            SIGPOLL = 30,
-            SIGPWR = 31,
-            SIGSYS = 32,
+            SIGHUP = 0,
+            SIGINT = 1,
+            SIGQUIT = 2,
+            SIGILL = 3,
+            SIGTRAP = 4,
+            SIGABRT = 5,
+            SIGBUS = 6,
+            SIGFPE = 7,
+            SIGKILL = 8,
+            SIGUSR1 = 9,
+            SIGSEGV = 10,
+            SIGUSR2 = 11,
+            SIGPIPE = 12,
+            SIGALRM = 13,
+            SIGTERM = 14,
+            SIGSTKFLT = 15,
+            SIGCHLD = 16,
+            SIGCONT = 17,
+            SIGSTOP = 18,
+            SIGTSTP = 19,
+            SIGTTIN = 20,
+            SIGTTOU = 21,
+            SIGURG = 22,
+            SIGXCPU = 23,
+            SIGXFSZ = 24,
+            SIGVTALRM = 25,
+            SIGPROF = 26,
+            SIGWINCH = 27,
+            SIGIO = 28,
+            SIGPOLL = 29,
+            SIGPWR = 30,
+            SIGSYS = 31,
         };
 
 


### PR DESCRIPTION
### Make reschedule synchronous

- switch tasks while switching current
- don't borrow kernel stacks from other tasks this is prone to errors

Imagine the following scenario
```
PID 14 parent
    PID 15 child
    PID 16 thread
    
PID 14 does wait
Timer_interrupt
PID 15 calls exit_group
PID 15 signals pid 16
PID 15 starts doExit
Timer interrupt
PID 16 default_handler->doExit()
Timer interrupt
PID 14 ...
TImer interrupt
PID 15 starts using its own stack and corrupts it
Crash
```
Lets refactor the scheduling logic to allow us to use the current tasks kernel stack when servicing signals.