### PR TITLE
kfs: signals: rt_signals

### DIFF
--- a/src/kernel/sched/signals.zig
+++ b/src/kernel/sched/signals.zig
@@ -2,7 +2,8 @@ const tsk = @import("./task.zig");
 const krn = @import("../main.zig");
 const std = @import("std");
 const arch = @import("arch");
-pub const SIG_COUNT: u8 = 32;
+
+pub const NSIG: u8 = 64;
 
 pub const Sigval = extern union {
     int: i32,
@@ -116,16 +117,30 @@ pub const sigset_t = extern struct {
         };
     }
 
+    pub fn toU64(self: *const sigset_t) u64 {
+        return @as(u64, self._bits[0]) | (@as(u64, self._bits[1]) << 32);
+    }
+
+    pub fn fromU64(val: u64) sigset_t {
+        return sigset_t{ ._bits = .{
+            @truncate(val),
+            @truncate(val >> 32),
+        } };
+    }
+
     pub fn sigAddSet(self: *sigset_t, signal: Signal) void {
-        self._bits[0] |= signal.sigsetMask();
+        const idx = signal.toInt();
+        self._bits[idx / 32] |= (@as(u32, 1) << @intCast(idx % 32));
     }
 
     pub fn sigDelSet(self: *sigset_t, signal: Signal) void {
-        self._bits[0] &= ~signal.sigsetMask();
+        const idx = signal.toInt();
+        self._bits[idx / 32] &= ~(@as(u32, 1) << @intCast(idx % 32));
     }
 
     pub fn sigIsSet(self: *const sigset_t, signal: Signal) bool {
-        return (self._bits[0] & signal.sigsetMask()) != 0;
+        const idx = signal.toInt();
+        return (self._bits[idx / 32] & (@as(u32, 1) << @intCast(idx % 32))) != 0;
     }
 };
 
@@ -133,7 +148,7 @@ pub const HandlerFn = *align(1) const fn (i32) callconv(.c) void;
 pub const SigactionFn = *const fn (i32, *const Siginfo, ?*anyopaque) callconv(.c) void;
 pub const RestorerFn = *const fn () callconv(.c) void;
 
-pub const Sigaction = struct {
+pub const Sigaction = extern struct {
     handler: extern union {
         handler: ?HandlerFn,
         sigaction: ?SigactionFn,
@@ -202,8 +217,14 @@ pub const Signal = enum(u8) {
     SIGPWR,         // Terminate   Power supply failure                 No         31
     SIGSYS,         // Dump        Bad system call                      No         32
 
-    pub inline fn sigsetMask(sig: Signal) u32 {
-        const mask = @as(u32, 1) << @intCast(sig.toInt());
+    // RT
+    SIGRT00, SIGRT01, SIGRT02, SIGRT03, SIGRT04, SIGRT05, SIGRT06, SIGRT07,
+    SIGRT08, SIGRT09, SIGRT10, SIGRT11, SIGRT12, SIGRT13, SIGRT14, SIGRT15,
+    SIGRT16, SIGRT17, SIGRT18, SIGRT19, SIGRT20, SIGRT21, SIGRT22, SIGRT23,
+    SIGRT24, SIGRT25, SIGRT26, SIGRT27, SIGRT28, SIGRT29, SIGRT30, SIGRT31,
+
+    pub inline fn sigsetMask(sig: Signal) u64 {
+        const mask = @as(u64, 1) << @intCast(sig.toInt());
         return mask;
     }
 
@@ -239,11 +260,11 @@ const SigRes = struct {
 };
 
 pub const SigPending = struct {
-    set: std.StaticBitSet(32) = std.StaticBitSet(32).initEmpty(),
+    set: std.StaticBitSet(NSIG) = std.StaticBitSet(NSIG).initEmpty(),
 
     pub fn init() SigPending{
         return SigPending{
-            .set = std.StaticBitSet(32).initEmpty(),
+            .set = std.StaticBitSet(NSIG).initEmpty(),
         };
     }
 
@@ -251,47 +272,17 @@ pub const SigPending = struct {
         self.set.set(signal.toInt());
     }
 
-    pub inline fn getRaw(self: *SigPending) u32 {
+    pub inline fn getRaw(self: *SigPending) u64 {
         return @bitCast(self.set);
     }
 };
 
 pub const SigHand = struct {
-    actions: std.EnumArray(Signal, Sigaction) =
-        std.EnumArray(Signal, Sigaction).init(.{
-            .SIGHUP     = default_sigaction,
-            .SIGINT     = default_sigaction,
-            .SIGQUIT    = default_sigaction,
-            .SIGILL     = default_sigaction,
-            .SIGTRAP    = default_sigaction,
-            .SIGABRT    = default_sigaction,
-            .SIGBUS     = default_sigaction,
-            .SIGFPE     = default_sigaction,
-            .SIGKILL    = default_sigaction,
-            .SIGUSR1    = default_sigaction,
-            .SIGSEGV    = default_sigaction,
-            .SIGUSR2    = default_sigaction,
-            .SIGPIPE    = default_sigaction,
-            .SIGALRM    = default_sigaction,
-            .SIGTERM    = default_sigaction,
-            .SIGSTKFLT  = default_sigaction,
-            .SIGCHLD    = ignore_sigaction,
-            .SIGCONT    = default_sigaction,
-            .SIGSTOP    = default_sigaction,
-            .SIGTSTP    = default_sigaction,
-            .SIGTTIN    = default_sigaction,
-            .SIGTTOU    = default_sigaction,
-            .SIGURG     = default_sigaction,
-            .SIGXCPU    = default_sigaction,
-            .SIGXFSZ    = default_sigaction,
-            .SIGVTALRM  = default_sigaction,
-            .SIGPROF    = default_sigaction,
-            .SIGWINCH   = default_sigaction,
-            .SIGIO      = default_sigaction,
-            .SIGPOLL    = default_sigaction,
-            .SIGPWR     = default_sigaction,
-            .SIGSYS     = default_sigaction,
-        }),
+    actions: std.EnumArray(Signal, Sigaction) = blk: {
+        var arr = std.EnumArray(Signal, Sigaction).initFill(default_sigaction);
+        arr.set(.SIGCHLD, ignore_sigaction);
+        break :blk arr;
+    },
     ref: krn.RefCount = krn.RefCount.init(),
 
     pub fn init() SigHand {
@@ -328,7 +319,7 @@ pub const SigHand = struct {
         const lock_state = krn.task.current.thread_data.?.lock.lock_irq_disable();
         defer krn.task.current.thread_data.?.lock.unlock_irq_enable(lock_state);
 
-        const static_bit: std.StaticBitSet(32) = krn.task.current.getRealPending();
+        const static_bit: std.StaticBitSet(NSIG) = krn.task.current.getRealPending();
         var iterator = static_bit.iterator(.{});
 
         while (iterator.next()) |i| {

--- a/src/kernel/sched/task.zig
+++ b/src/kernel/sched/task.zig
@@ -529,14 +529,14 @@ pub const Task = struct {
     pub fn hasPendingSignal(self: *Task) bool {
         return (
             (self.sigpending.getRaw() | self.thread_data.?.pending.getRaw())
-            & (~self.sigmask._bits[0])
+            & (~self.sigmask.toU64())
         ) != 0;
     }
 
-    pub fn getRealPending(self: *Task) std.StaticBitSet(32) {
+    pub fn getRealPending(self: *Task) std.StaticBitSet(signal.NSIG) {
         const real_pending = (
             self.sigpending.getRaw() | self.thread_data.?.pending.getRaw()
-        ) & (~self.sigmask._bits[0]);
+        ) & (~self.sigmask.toU64());
         return @bitCast(real_pending);
     }
 

--- a/src/kernel/syscalls/kill.zig
+++ b/src/kernel/syscalls/kill.zig
@@ -43,7 +43,7 @@ fn send_signal(_task: *tsk.Task, signal: i32, tid: u32) !u32 {
 
 /// tid == 0 - send to process
 pub fn doKill(pid: i32, sig: i32, tid: u32) !u32 {
-    if (sig < 0 or sig > signals.Signal.SIGSYS.toPosix())
+    if (sig < 0 or sig > @as(i32, signals.NSIG))
         return errors.EINVAL;
     if (pid == 0 or pid < -1) {
         const lock_state = tsk.tasks_lock.lock_irq_disable();

--- a/src/kernel/syscalls/sigaction.zig
+++ b/src/kernel/syscalls/sigaction.zig
@@ -6,7 +6,7 @@ const krn = @import("../main.zig");
 const std = @import("std");
 
 fn do_sigaction(sig: u32, act: ?*signals.Sigaction, oact: ?*signals.Sigaction) !u32 {
-    if (sig == 0 or sig > signals.Signal.SIGSYS.toPosix())
+    if (sig == 0 or sig > signals.NSIG)
         return errors.EINVAL;
     const signal = signals.Signal.fromPosix(@intCast(sig));
     if (signal == .SIGKILL or signal == .SIGSTOP)
@@ -99,33 +99,31 @@ pub fn sigprocmask(
     set: ?*signals.sigset_t,
     oset: ?*signals.sigset_t,
 ) !u32 {
-    var oldset: u32 = 0;
-    var newset: u32 = 0;
-    var new_blocked: signals.sigset_t = signals.sigset_t.init();
-    oldset = tsk.current.sigmask._bits[0];
+    const oldset: u64 = tsk.current.sigmask.toU64();
     if (set) |_set| {
-        newset = _set._bits[0];
-        new_blocked = tsk.current.sigmask;
+        const newset: u64 = _set.toU64();
+        var blocked: u64 = oldset;
         switch (how) {
             SIG_BLOCK => {
-                new_blocked._bits[0] |= newset;
+                blocked |= newset;
             },
             SIG_UNBLOCK => {
-                new_blocked._bits[0] &= ~newset;
+                blocked &= ~newset;
             },
             SIG_SETMASK => {
-                new_blocked._bits[0] = newset;
+                blocked = newset;
             },
             else => {
                 return errors.EINVAL;
             }
         }
+        var new_blocked = signals.sigset_t.fromU64(blocked);
         new_blocked.sigDelSet(signals.Signal.SIGKILL);
         new_blocked.sigDelSet(signals.Signal.SIGSTOP);
         tsk.current.sigmask = new_blocked;
     }
     if (oset) |_oset| {
-        _oset._bits[0] = oldset;
+        _oset.* = signals.sigset_t.fromU64(oldset);
     }
     return 0;
 }
@@ -140,10 +138,11 @@ pub fn rt_sigpending(
 }
 
 pub fn sigpending(uset: ?*signals.sigset_t) u32 {
-    var set = signals.sigset_t.init();
     const task_raw = krn.task.current.sigpending.getRaw();
     const thread_raw = krn.task.current.thread_data.?.pending.getRaw();
-    set._bits[0] = (task_raw | thread_raw) & krn.task.current.sigmask._bits[0];
+    const set = signals.sigset_t.fromU64(
+        (task_raw | thread_raw) & krn.task.current.sigmask.toU64()
+    );
     if (uset) |_uset| {
         _uset.* = set;
     }
@@ -217,7 +216,7 @@ pub fn rt_sigtimedwait(
     while (true) {
         const task_raw = krn.task.current.sigpending.getRaw();
         const thread_raw = krn.task.current.thread_data.?.pending.getRaw();
-        const all_pending: std.StaticBitSet(32) = @bitCast(task_raw | thread_raw);
+        const all_pending: std.StaticBitSet(signals.NSIG) = @bitCast(task_raw | thread_raw);
         var iterator = all_pending.iterator(.{});
         while (iterator.next()) |sig| {
             const signal = signals.Signal.fromInt(sig);

--- a/types/types.zig
+++ b/types/types.zig
@@ -601,6 +601,9 @@ pub const arch = struct {
 
     };
 
+    pub const sw = struct {
+    };
+
     pub const syscalls = struct {
         pub const thread = struct {
             pub const UserDesc = extern struct {
@@ -833,6 +836,7 @@ pub const kernel = struct {
             ctty : ?*kernel.fs.file.File= null,
             stack_bottom : u32,
             state : kernel.task.TaskState,
+            kernel_esp : u32= 0,
             regs : arch.Regs,
             tls : u32= 0,
             limit : u32= 0,
@@ -879,7 +883,6 @@ pub const kernel = struct {
     };
 
     pub const sched = struct {
-        pub extern fn schedule(*arch.Regs)*arch.Regs;
     };
 
     pub const Mutex = struct {
@@ -925,7 +928,7 @@ pub const kernel = struct {
             _bits : [2]u32,
         };
 
-        pub const Sigaction = struct {
+        pub const Sigaction = extern struct {
             handler : extern union { handler: ?*const fn(i32) void, sigaction: ?*const fn(i32, *const kernel.signals.Siginfo, ?*anyopaque) void },
             flags : u32,
             restorer : ?*const fn() void= null,
@@ -965,11 +968,43 @@ pub const kernel = struct {
             SIGPOLL = 29,
             SIGPWR = 30,
             SIGSYS = 31,
+            SIGRT00 = 32,
+            SIGRT01 = 33,
+            SIGRT02 = 34,
+            SIGRT03 = 35,
+            SIGRT04 = 36,
+            SIGRT05 = 37,
+            SIGRT06 = 38,
+            SIGRT07 = 39,
+            SIGRT08 = 40,
+            SIGRT09 = 41,
+            SIGRT10 = 42,
+            SIGRT11 = 43,
+            SIGRT12 = 44,
+            SIGRT13 = 45,
+            SIGRT14 = 46,
+            SIGRT15 = 47,
+            SIGRT16 = 48,
+            SIGRT17 = 49,
+            SIGRT18 = 50,
+            SIGRT19 = 51,
+            SIGRT20 = 52,
+            SIGRT21 = 53,
+            SIGRT22 = 54,
+            SIGRT23 = 55,
+            SIGRT24 = 56,
+            SIGRT25 = 57,
+            SIGRT26 = 58,
+            SIGRT27 = 59,
+            SIGRT28 = 60,
+            SIGRT29 = 61,
+            SIGRT30 = 62,
+            SIGRT31 = 63,
         };
 
 
         pub const SigPending = struct {
-            set : std.bit_set.IntegerBitSet(32),
+            set : std.bit_set.ArrayBitSet(usize, 64),
         };
 
         pub const SigHand = struct {


### PR DESCRIPTION
Add support for rt_signals to make go programs run
Makes NSIG 64, bitset takes into account second u32
all rt_signals use default sigaction. This allows a simple hello world program written
in go to run