### PR TITLE
kfs: syscalls: implement epoll

### DIFF
--- a/src/drivers/platform/tty.zig
+++ b/src/drivers/platform/tty.zig
@@ -191,10 +191,14 @@ fn tty_read(file: *krn.fs.File, buf: [*]u8, size: usize) !usize {
                 defer _tty.lock.unlock();
                 return @intCast(_tty.file_buff.readLineInto(buf[0..size]));
             }
+            if (file.flags & krn.fs.file.O_NONBLOCK != 0) {
+                _tty.lock.unlock();
+                return krn.errors.PosixError.EAGAIN;
+            }
             _tty.lock.unlock();
             _tty.read_queue.wait(true, 0);
             if (krn.task.current.hasPendingSignal())
-                return krn.errors.PosixError.EINTR;
+                return krn.errors.PosixError.ERESTARTSYS;
         }
     } else {
         const vmin: u8 = _tty.term.c_cc[t.VMIN];
@@ -238,11 +242,16 @@ fn tty_read(file: *krn.fs.File, buf: [*]u8, size: usize) !usize {
                     }
                     return @intCast(n);
                 }
+                if (file.flags & krn.fs.file.O_NONBLOCK != 0) {
+                    if (to_read > 0)
+                        _tty.lock.unlock();
+                    return krn.errors.PosixError.EAGAIN;
+                }
                 if (to_read > 0)
                     _tty.lock.unlock();
                 _tty.read_queue.wait(true, to_sleep);
                 if (krn.task.current.hasPendingSignal())
-                    return krn.errors.PosixError.EINTR;
+                    return krn.errors.PosixError.ERESTARTSYS;
                 continue;
             }
             const to_read = @min(avail, size);

--- a/src/kernel/fs/epoll.zig
+++ b/src/kernel/fs/epoll.zig
@@ -1,0 +1,51 @@
+const kernel = @import("../main.zig");
+const std = @import("std");
+
+pub const EpollEntry = struct {
+    fd: i32,
+    events: u32,
+    data: u64,
+};
+
+pub const EpollState = struct {
+    entries: std.ArrayList(EpollEntry) = undefined,
+
+    pub fn init(self: *EpollState) !void {
+        self.entries = try std.ArrayList(EpollEntry).initCapacity(
+            kernel.mm.kernel_allocator.allocator(),
+            4,
+        );
+    }
+
+    pub fn deinit(self: *EpollState) void {
+        self.entries.deinit(kernel.mm.kernel_allocator.allocator());
+    }
+};
+
+pub const ops = kernel.fs.FileOps {
+    .open = open,
+    .close = close,
+    .read =  read,
+    .write = write,
+    .ioctl = null,
+    .poll = null,
+    .lseek = null
+};
+
+pub fn open(_: *kernel.fs.File, _: *kernel.fs.Inode) !void {
+    return kernel.errors.PosixError.ENOSYS;
+}
+
+pub fn close(file: *kernel.fs.File) void {
+    const epoll_data: *EpollState = @ptrCast(@alignCast(file.data));
+    epoll_data.deinit();
+    kernel.mm.kfree(epoll_data);
+}
+
+pub fn read(_: *kernel.fs.File, _: [*]u8, _: usize) !usize {
+    return kernel.errors.PosixError.ENOSYS;
+}
+
+pub fn write(_: *kernel.fs.File, _: [*]const u8, _: usize) !usize {
+    return kernel.errors.PosixError.ENOSYS;
+}

--- a/src/kernel/fs/fs.zig
+++ b/src/kernel/fs/fs.zig
@@ -37,6 +37,7 @@ pub const FileOps = file.FileOps;
 
 // Pipe
 pub const pipe = @import("./pipe.zig");
+pub const epoll = @import("./epoll.zig");
 
 pub const examplefs = @import("example/filesystem.zig");
 pub const sysfs = @import("sys/filesystem.zig");

--- a/src/kernel/fs/pipe.zig
+++ b/src/kernel/fs/pipe.zig
@@ -80,10 +80,13 @@ pub fn read(base: *krn.fs.File, buf: [*]u8, size: usize) !usize {
     while (pipe.rb.isEmpty()) {
         if (pipe.writers == 0)
             return 0;
+        if (base.flags & krn.fs.file.O_NONBLOCK != 0)
+            return krn.errors.PosixError.EAGAIN;
+
         var wq_node = krn.wq.WaitQueueNode.init(krn.task.current);
         wq_node.setup();
-
         pipe.read_queue.addToQueue(&wq_node);
+        
         pipe.lock.unlock();
         pipe.read_queue.waitIfInQueue(&wq_node, true, 0);
         if (krn.task.current.hasPendingSignal()) {
@@ -112,9 +115,11 @@ pub fn write(base: *krn.fs.File, buf: [*]const u8, size: usize) !usize {
     }
 
     while (pipe.rb.isFull()) {
+        if (base.flags & krn.fs.file.O_NONBLOCK != 0)
+            return krn.errors.PosixError.EAGAIN;
+
         var wq_node = krn.wq.WaitQueueNode.init(krn.task.current);
         wq_node.setup();
-
         pipe.write_queue.addToQueue(&wq_node);
         pipe.lock.unlock();
         pipe.write_queue.waitIfInQueue(&wq_node, true, 0);

--- a/src/kernel/net/socket.zig
+++ b/src/kernel/net/socket.zig
@@ -286,6 +286,8 @@ pub fn do_accept4(fd: u32, addr: u32, addr_len: u32, flags: u32) !u32 {
         }
         listener.lock.unlock();
 
+        if (file.flags & krn.fs.file.O_NONBLOCK != 0)
+            return krn.errors.PosixError.EAGAIN;
         listener.accept_wait.wait(true, 0);
         if (krn.task.current.hasPendingSignal())
             return krn.errors.PosixError.ERESTARTSYS;
@@ -341,6 +343,9 @@ pub fn do_connect(fd: u32, _addr_ptr: ?*anyopaque, addr_len: u32) !u32 {
     listener.accept_wait.wakeUpOne();
 
     while (sock.conn == null) {
+        if (file.flags & krn.fs.file.O_NONBLOCK != 0)
+            return krn.errors.PosixError.EAGAIN;
+
         krn.task.current.wakeup_time = krn.currentMs() + 10;
         krn.task.current.state = .INTERRUPTIBLE_SLEEP;
         krn.sched.reschedule();
@@ -363,6 +368,8 @@ pub fn do_recvfrom(base: *krn.fs.File, buf: [*]u8, size: usize) !usize {
         if (sock.conn == null) {
             return krn.errors.PosixError.ENOTCONN;
         }
+        if (base.flags & krn.fs.file.O_NONBLOCK != 0)
+            return krn.errors.PosixError.EAGAIN;
 
         var wq_node = krn.wq.WaitQueueNode.init(krn.task.current);
         wq_node.setup();
@@ -395,6 +402,9 @@ pub fn do_sendto(base: *krn.fs.File, buf: [*]const u8, size: usize) !usize {
     remote.lock.lock();
     defer remote.lock.unlock();
     while (remote.rb.isFull()) {
+        if (base.flags & krn.fs.file.O_NONBLOCK != 0)
+            return krn.errors.PosixError.EAGAIN;
+
         var wq_node = krn.wq.WaitQueueNode.init(krn.task.current);
         wq_node.setup();
 

--- a/src/kernel/syscalls/epoll.zig
+++ b/src/kernel/syscalls/epoll.zig
@@ -1,74 +1,248 @@
-const std = @import("std");
-const errors = @import("./error-codes.zig").PosixError;
 const krn = @import("../main.zig");
+const errors = @import("./error-codes.zig").PosixError;
 
-const EPOLL_CLOEXEC = krn.fs.file.O_CLOEXEC;
+const EPOLL_CTL_ADD: i32 = 1;
+const EPOLL_CTL_DEL: i32 = 2;
+const EPOLL_CTL_MOD: i32 = 3;
 
-const EPOLL_CTL_ADD = 1;
-const EPOLL_CTL_DEL = 2;
-const EPOLL_CTL_MOD = 3;
+const EPOLLIN: u32 = 0x001;
+const EPOLLPRI: u32 = 0x002;
+const EPOLLOUT: u32 = 0x004;
+const EPOLLERR: u32 = 0x008;
+const EPOLLHUP: u32 = 0x010;
 
-// Epoll event masks
-const EPOLLIN       : u32 = 0x00000001;
-const EPOLLPRI      : u32 = 0x00000002;
-const EPOLLOUT      : u32 = 0x00000004;
-const EPOLLERR      : u32 = 0x00000008;
-const EPOLLHUP      : u32 = 0x00000010;
-const EPOLLNVAL     : u32 = 0x00000020;
-const EPOLLRDNORM   : u32 = 0x00000040;
-const EPOLLRDBAND   : u32 = 0x00000080;
-const EPOLLWRNORM   : u32 = 0x00000100;
-const EPOLLWRBAND   : u32 = 0x00000200;
-const EPOLLMSG      : u32 = 0x00000400;
-const EPOLLRDHUP    : u32 = 0x00002000;
-
-const EpollEvent = struct {
+pub const EpollEvent = extern struct {
     events: u32,
-    data:   u64,
+    data: u64,
 };
 
-fn doEpollCreate(flags: u32) !u32 {
-    _ = flags;
-    return errors.ENOSYS;
+
+fn getState(epfd: i32) !*krn.fs.epoll.EpollState {
+    if (epfd < 0)
+        return errors.EBADF;
+
+    const file = krn.task.current.files.fds.get(@intCast(epfd)) orelse
+        return errors.EBADF;
+    if (file.ops != &krn.fs.epoll.ops)
+        return errors.EINVAL;
+    return @ptrCast(@alignCast(file.data));
 }
 
-pub fn epoll_create(size: i32) !u32 {
-    krn.logger.DEBUG("epoll_create {d}", .{size});
-    if (size < 0)
-        return errors.EINVAL;
-    return try doEpollCreate(0);
+fn findEntry(entries: []krn.fs.epoll.EpollEntry, fd: i32) ?usize {
+    for (entries, 0..) |entry, idx| {
+        if (entry.fd == fd)
+            return idx;
+    }
+    return null;
+}
+
+fn epollToPoll(events: u32) u16 {
+    var out: u16 = 0;
+    if (events & EPOLLIN != 0)
+        out |= krn.poll.POLLIN;
+    if (events & EPOLLPRI != 0)
+        out |= krn.poll.POLLPRI;
+    if (events & EPOLLOUT != 0)
+        out |= krn.poll.POLLOUT;
+    return out;
+}
+
+fn pollToEpoll(events: u16) u32 {
+    var out: u32 = 0;
+    if (events & krn.poll.POLLIN != 0)
+        out |= EPOLLIN;
+    if (events & krn.poll.POLLPRI != 0)
+        out |= EPOLLPRI;
+    if (events & krn.poll.POLLOUT != 0)
+        out |= EPOLLOUT;
+    if (events & krn.poll.POLLERR != 0)
+        out |= EPOLLERR;
+    if (events & krn.poll.POLLHUP != 0)
+        out |= EPOLLHUP;
+    return out;
+}
+
+fn releaseEpollState(rc: *krn.RefCount) void {
+    const inode: *krn.fs.Inode = @fieldParentPtr("ref", rc);
+    krn.mm.kfree(inode);
 }
 
 pub fn epoll_create1(flags: u32) !u32 {
-    krn.logger.DEBUG("epoll_create1 {x}", .{flags});
-    return try doEpollCreate(flags);
+    const cloexec: u32 = krn.fs.file.O_CLOEXEC;
+    if (flags & ~cloexec != 0)
+        return errors.EINVAL;
+
+    const state = krn.mm.kmalloc(krn.fs.epoll.EpollState) orelse
+        return errors.ENOMEM;
+    errdefer krn.mm.kfree(state);
+    try state.init();
+    errdefer state.deinit();
+
+    const inode = try krn.fs.Inode.allocEmpty();
+    errdefer krn.mm.kfree(inode);
+    inode.fops = &krn.fs.epoll.ops;
+    inode.mode = krn.fs.UMode.regular();
+
+    const file = try krn.fs.File.pseudo(inode);
+    errdefer file.ref.put();
+
+    inode.ref.put(); // pseudo referenced inode
+    file.mode = krn.fs.UMode.regular();
+    file.flags |= krn.fs.file.O_RDWR;
+    file.data = state;
+
+    const fd = try krn.task.current.files.getNextFD();
+    errdefer _ = krn.task.current.files.releaseFD(fd);
+
+    try krn.task.current.files.setFD(fd, file);
+    if (flags & cloexec != 0)
+        krn.task.current.files.closexec.set(fd);
+    return @intCast(fd);
 }
 
-pub fn epoll_ctl(epfd: i32, op: i32, fd: i32, epoll_event: ?*EpollEvent) !u32 {
-    krn.logger.DEBUG(
-        "epoll_ctl epfd: {d} op: {x} fd: {d} event: {any}",
-        .{epfd, op, fd, epoll_event}
-    );
-    return errors.ENOSYS;
+pub fn epoll_create(size: i32) !u32 {
+    if (size <= 0)
+        return errors.EINVAL;
+    return try epoll_create1(0);
 }
 
-pub fn epoll_wait(epfd: i32, events: [*]EpollEvent, n: i32, timeout: i32) !u32 {
-    krn.logger.DEBUG(
-        "epoll_wait epfd: {d}, events: {any}, n: {d}, timeout: {d}",
-        .{epfd, events, n, timeout}
-    );
-    return errors.ENOSYS;
+pub fn epoll_ctl(epfd: i32, op: i32, fd: i32, event: ?*const EpollEvent) !u32 {
+    if (fd == epfd)
+        return errors.EINVAL;
+    if (fd < 0)
+        return errors.EBADF;
+
+    const state = try getState(epfd);
+
+    switch (op) {
+        EPOLL_CTL_ADD => {
+            const ev = event orelse return errors.EFAULT;
+            const file = krn.task.current.files.fds.get(@intCast(fd)) orelse
+                return errors.EBADF;
+            if (file.inode.fops == &krn.fs.epoll.ops)
+                return errors.ELOOP;
+            if (findEntry(state.entries.items, fd) != null)
+                return errors.EEXIST;
+            try state.entries.append(krn.mm.kernel_allocator.allocator(), .{
+                .fd = fd,
+                .events = ev.events,
+                .data = ev.data,
+            });
+            krn.logger.DEBUG(
+                "[epoll_ctl ADD] pid={d} epfd={d} fd={d} events=0x{x}",
+                .{ krn.task.current.pid, epfd, fd, ev.events },
+            );
+        },
+        EPOLL_CTL_DEL => {
+            const idx = findEntry(state.entries.items, fd) orelse
+                return errors.ENOENT;
+            const last = state.entries.items.len - 1;
+            state.entries.items[idx] = state.entries.items[last];
+            state.entries.items.len = last;
+        },
+        EPOLL_CTL_MOD => {
+            const ev = event orelse return errors.EFAULT;
+            const idx = findEntry(state.entries.items, fd) orelse
+                return errors.ENOENT;
+            state.entries.items[idx].events = ev.events;
+            state.entries.items[idx].data = ev.data;
+            krn.logger.DEBUG(
+                "[epoll_ctl MOD] pid={d} epfd={d} fd={d} events=0x{x}",
+                .{ krn.task.current.pid, epfd, fd, ev.events },
+            );
+        },
+        else => return errors.EINVAL,
+    }
+
+    return 0;
 }
 
-pub fn epoll_pwait(
-    epfd: i32, events: [*]EpollEvent, n: i32, timeout: i32,
-    sigmask: ?*krn.signals.sigset_t,
-) !u32 {
-    krn.logger.DEBUG(
-        "epoll_wait epfd: {d}, events: {any}, n: {d}, timeout: {d} sigmask: {any}",
-        .{epfd, events, n, timeout, sigmask}
-    );
-    return errors.ENOSYS;
+pub fn epoll_wait(epfd: i32, events: ?[*]EpollEvent, maxevents: i32, timeout_ms: i32) !u32 {
+    const out_events = events orelse return errors.EFAULT;
+    if (maxevents <= 0)
+        return errors.EINVAL;
+    if (timeout_ms < -1)
+        return errors.EINVAL;
+
+    const state = try getState(epfd);
+    const start_time = krn.currentMs();
+    var poll_table = krn.poll.PollTable.init();
+    defer poll_table.deinit();
+    var poll_table_added = false;
+    var iter: u32 = 0;
+
+    while (true) {
+        iter += 1;
+        var ready_count: u32 = 0;
+
+        for (state.entries.items) |entry| {
+            if (ready_count >= @as(u32, @intCast(maxevents)))
+                break;
+
+            var ready_events: u32 = 0;
+            if (entry.fd >= 0) {
+                if (krn.task.current.files.fds.get(@intCast(entry.fd))) |file| {
+                    file.ref.get();
+                    defer file.ref.put();
+
+                    var pollfd = krn.poll.PollFd{
+                        .fd = entry.fd,
+                        .events = epollToPoll(entry.events),
+                        .revents = 0,
+                    };
+
+                    if (file.ops.poll) |_poll| {
+                        _ = try _poll(file, &pollfd, if (poll_table_added) null else &poll_table);
+                    } else {
+                        pollfd.revents |= krn.poll.POLLNVAL;
+                    }
+                    ready_events = pollToEpoll(pollfd.revents);
+                } else {
+                    ready_events = EPOLLERR | EPOLLHUP;
+                }
+            }
+
+            if (ready_events != 0) {
+                out_events[ready_count] = .{
+                    .events = ready_events,
+                    .data = entry.data,
+                };
+                ready_count += 1;
+            }
+        }
+
+        if (ready_count > 0) {
+            return ready_count;
+        }
+        if (timeout_ms == 0) {
+            return 0;
+        }
+
+        poll_table_added = true;
+        if (timeout_ms < 0) {
+            krn.task.current.wakeup_time = 0;
+        } else {
+            const curr_time = krn.currentMs();
+            const elapsed = curr_time - start_time;
+            const to_sleep = @as(u32, @intCast(timeout_ms)) -| elapsed;
+            if (to_sleep == 0) {
+                return 0;
+            }
+            krn.task.current.wakeup_time = curr_time + to_sleep;
+        }
+
+        krn.task.current.state = .INTERRUPTIBLE_SLEEP;
+        krn.sched.reschedule();
+        if (krn.task.current.hasPendingSignal()) {
+            return errors.EINTR;
+        }
+    }
+}
+
+pub fn epoll_pwait(epfd: i32, events: ?[*]EpollEvent, maxevents: i32, timeout_ms: i32, sigmask: u32, sigsetsize: u32) !u32 {
+    _ = sigmask;
+    _ = sigsetsize;
+    return try epoll_wait(epfd, events, maxevents, timeout_ms);
 }
 
 pub fn epoll_pwait2(
@@ -79,5 +253,5 @@ pub fn epoll_pwait2(
         "epoll_wait epfd: {d}, events: {any}, n: {d}, timeout: {any} sigmask: {any}",
         .{epfd, events, n, timeout, sigmask}
     );
-    return errors.ENOSYS;
+    return try epoll_wait(epfd, events, n, @intCast(timeout.toMSec()));
 }

--- a/src/kernel/syscalls/epoll.zig
+++ b/src/kernel/syscalls/epoll.zig
@@ -11,6 +11,9 @@ const EPOLLOUT: u32 = 0x004;
 const EPOLLERR: u32 = 0x008;
 const EPOLLHUP: u32 = 0x010;
 
+const EPOLLONESHOT: u32 = 1 << 30;
+const EPOLLET: u32 = 1 << 31;
+
 pub const EpollEvent = extern struct {
     events: u32,
     data: u64,
@@ -116,7 +119,10 @@ pub fn epoll_ctl(epfd: i32, op: i32, fd: i32, event: ?*const EpollEvent) !u32 {
 
     switch (op) {
         EPOLL_CTL_ADD => {
-            const ev = event orelse return errors.EFAULT;
+            const ev = event orelse
+                return errors.EFAULT;
+            if (ev.events & (EPOLLONESHOT | EPOLLET) != 0)
+                return errors.ENOSYS;
             const file = krn.task.current.files.fds.get(@intCast(fd)) orelse
                 return errors.EBADF;
             if (file.inode.fops == &krn.fs.epoll.ops)
@@ -141,7 +147,10 @@ pub fn epoll_ctl(epfd: i32, op: i32, fd: i32, event: ?*const EpollEvent) !u32 {
             state.entries.items.len = last;
         },
         EPOLL_CTL_MOD => {
-            const ev = event orelse return errors.EFAULT;
+            const ev = event orelse
+                return errors.EFAULT;
+            if (ev.events & (EPOLLONESHOT | EPOLLET) != 0)
+                return errors.ENOSYS;
             const idx = findEntry(state.entries.items, fd) orelse
                 return errors.ENOENT;
             state.entries.items[idx].events = ev.events;

--- a/src/kernel/time/spec.zig
+++ b/src/kernel/time/spec.zig
@@ -30,6 +30,10 @@ pub const kernel_timespec = extern struct {
         };
     }
 
+    pub inline fn toMSec(self: *const kernel_timespec) usize {
+        return @as(usize, @intCast(self.tv_sec)) * 1000 +| @as(usize, @intCast(self.tv_nsec)) / 1000000;
+    }
+
     pub inline fn sub(
         self: *const kernel_timespec,
         other: *const kernel_timespec

--- a/types/types.zig
+++ b/types/types.zig
@@ -1242,6 +1242,19 @@ pub const kernel = struct {
 
         };
 
+        pub const epoll = struct {
+            pub const EpollEntry = struct {
+                fd : i32,
+                events : u32,
+                data : u64,
+            };
+
+            pub const EpollState = struct {
+                entries : std.array_list.Aligned(kernel.fs.epoll.EpollEntry, null),
+            };
+
+        };
+
         pub const examplefs = struct {
             pub const ExampleFileSystem = struct {
                 base : kernel.fs.filesystem.FileSystem,
@@ -1617,6 +1630,11 @@ pub const kernel = struct {
         };
 
         pub const epoll = struct {
+            pub const EpollEvent = extern struct {
+                events : u32,
+                data : u64,
+            };
+
         };
 
     };


### PR DESCRIPTION
Adds all necessary syscalls for epoll.
Under the hood epoll works exactly like poll.
For now we don't see the value in implementing it fully. If in the future is is necessary we will correct this implementation and have the events be delivered even when the task is not waiting on them.