### PR TITLE
Smp TLB: fix deadlock when delivering IPIs and waiting for ACKS

### DIFF
--- a/src/arch/x86/smp/main.zig
+++ b/src/arch/x86/smp/main.zig
@@ -98,6 +98,7 @@ pub fn idle() noreturn {
         krn.sched.schedule();
 
         krn.sched.processTasks();
+        while (krn.mm.deferredFreeOne()) {}
     }
 }
 
@@ -121,6 +122,7 @@ pub export fn apMain() noreturn {
     );
     // Percpu variables can be used
 
+    krn.mm.deferredFreeReset();
     logical_id.set(curr_logical_id);
     physical_id.set(curr_phys_id);
 

--- a/src/kernel/mm/heap.zig
+++ b/src/kernel/mm/heap.zig
@@ -1,3 +1,4 @@
+const arch = @import("arch");
 const pmm = @import("arch").pmm.PMM;
 const vmm = @import("arch").vmm.VMM;
 const Mutex = @import("../sched/mutex.zig").Mutex;
@@ -16,9 +17,41 @@ pub const FreeListNode = extern struct {
 pub const AllocHeader = extern struct {
     block_size: usize,
     head: ?*FreeList,
-    unused_1: usize = 0,
-    unused_2: usize = 0,
+    list: krn.list.ListHead = .{ .next = null, .prev = null },
 };
+
+const deferred_list = arch.smp.PerCpu(
+    krn.list.ListHead,
+    krn.list.ListHead{ .next = null, .prev = null },
+    opaque {}
+);
+
+pub fn deferredFreeReset() void {
+    deferred_list.ptr().setup();
+}
+
+pub fn deferredFreeOne() bool {
+    var addr: usize = 0;
+    var freed: bool = false;
+    arch.cpu.disableInterrupts();
+    const head = deferred_list.ptr();
+    if (!head.isEmpty()) {
+        const first = head.next.?;
+        first.del();
+        addr = @intFromPtr(first.entry(AllocHeader, "list")) + @sizeOf(AllocHeader);
+    }
+    arch.cpu.enableInterrupts();
+    if (addr == 0)
+        return freed;
+    if (krn.mm.kheap.isAddrInRange(addr)) {
+        krn.mm.kheap.free(addr);
+        freed = true;
+    } else if (krn.mm.vheap.isAddrInRange(addr)) {
+        krn.mm.vheap.free(addr);
+        freed = true;
+    }
+    return freed;
+}
 
 pub const FreeList = struct {
     start_addr: usize,
@@ -169,7 +202,15 @@ pub const FreeList = struct {
         return header;
     }
 
+    fn deferFree(self: *FreeList, addr: usize) void {
+        const header: *AllocHeader = self.getAllocHeader(addr) orelse return;
+        header.list.setup();
+        deferred_list.ptr().addTail(&header.list);
+    }
+
     pub fn free(self: *FreeList, addr: usize) void {
+        if (!arch.cpu.areIntEnabled())
+            return self.deferFree(addr);
         var prev: ?*FreeListNode = undefined;
         const lock_state = krn.mm.mem_lock.lock_irq_disable();
         defer krn.mm.mem_lock.unlock_irq_enable(lock_state);
@@ -374,5 +415,9 @@ pub const FreeList = struct {
         if (header == null)
             return 0;
         return header.?.block_size - @sizeOf(AllocHeader);
+    }
+
+    pub fn isAddrInRange(self: *FreeList, addr: usize) bool {
+        return addr >= self.start_addr and addr < self.end_addr;
     }
 };

--- a/src/kernel/mm/heap.zig
+++ b/src/kernel/mm/heap.zig
@@ -249,6 +249,9 @@ pub const FreeList = struct {
         contig: bool,
         user: bool
     ) !usize {
+        if (!arch.cpu.areIntEnabled() and arch.smp.smp_enabled) {
+            @panic("Fix code that allocates in atomic context\n");
+        }
         // Total size of the block to allocate (including header)
         const total_size = self.alignToPtr(size + @sizeOf(AllocHeader));
 

--- a/src/kernel/mm/init.zig
+++ b/src/kernel/mm/init.zig
@@ -32,6 +32,8 @@ pub const vmallocSlice = @import("./vmalloc.zig").vmallocSlice;
 pub const vfreeSlice = @import("./vmalloc.zig").vfreeSlice;
 pub const vfree = @import("./vmalloc.zig").vfree;
 pub const vsize = @import("./vmalloc.zig").vsize;
+pub const deferredFreeOne = heap.deferredFreeOne;
+pub const deferredFreeReset = heap.deferredFreeReset;
 
 pub const PAGE_OFFSET: usize = 0xC0000000;
 pub const PAGE_SIZE: usize = arch.PAGE_SIZE;
@@ -174,6 +176,7 @@ pub fn mmInit(info: *multiboot.Multiboot) void {
     }
 
     kernel_allocator = KernelAllocator{};
+    heap.deferredFreeReset();
 }
 
 // create page

--- a/src/kernel/sched/kthread.zig
+++ b/src/kernel/sched/kthread.zig
@@ -17,8 +17,6 @@ fn threadWrapper() callconv(.c) noreturn {
     arch.cpu.enableInterrupts();
     tsk.current().result = tsk.current().threadfn.?(tsk.current().arg);
     tsk.current().finish(false);
-    if (tsk.current().mm) |_mm|
-        _mm.ref.put();
     krn.sched.reschedule();
     while (true) {}
 }

--- a/src/kernel/sched/scheduler.zig
+++ b/src/kernel/sched/scheduler.zig
@@ -48,7 +48,8 @@ pub fn processTasks() void {
 
     if (task_to_free) |to_free| {
         if (to_free.mm) |_mm| {
-            _mm.delete();
+            if (_mm.ref.putAndTest())
+                _mm.delete();
         }
         kthreadStackFree(to_free.stack_bottom);
         km.kfree(to_free);

--- a/src/kernel/sched/task.zig
+++ b/src/kernel/sched/task.zig
@@ -447,16 +447,6 @@ pub const Task = struct {
         const lock_state = if (!tasks_locked) tasks_lock.lock_irq_disable() else false;
         defer if (!tasks_locked) tasks_lock.unlock_irq_enable(lock_state);
 
-        if (self.mm) |_mm| {
-            const mm_ref = _mm.ref.getValue();
-            defer {
-                if (mm_ref > 1) {
-                    self.mm = null;
-                }
-            }
-            _mm.ref.put();
-        }
-
         self.list.del();
         self.refcount.put();
         if (self == self.group_leader) {

--- a/src/kernel/syscalls/futex.zig
+++ b/src/kernel/syscalls/futex.zig
@@ -70,8 +70,8 @@ const FutexWaiter = struct {
 };
 
 fn getQueue(key: FutexKey) ?*FutexQueue {
-    const state = futexes_lock.lock_irq_disable();
-    defer futexes_lock.unlock_irq_enable(state);
+    futexes_lock.lock();
+    defer futexes_lock.unlock();
 
     if (futexes) |*map|
         return map.get(key);
@@ -79,30 +79,21 @@ fn getQueue(key: FutexKey) ?*FutexQueue {
 }
 
 fn getOrCreateQueue(key: FutexKey) !*FutexQueue {
-    {
-        const state = futexes_lock.lock_irq_disable();
-        defer futexes_lock.unlock_irq_enable(state);
+    futexes_lock.lock();
+    defer futexes_lock.unlock();
 
-        if (futexes == null) {
-            futexes = std.AutoHashMap(FutexKey, *FutexQueue).init(
-                krn.mm.kernel_allocator.allocator(),
-            );
-        }
-        if (futexes.?.get(key)) |q|
-            return q;
+    if (futexes == null) {
+        futexes = std.AutoHashMap(FutexKey, *FutexQueue).init(
+            krn.mm.kernel_allocator.allocator(),
+        );
     }
+    if (futexes.?.get(key)) |q|
+        return q;
 
     const queue = krn.mm.kmalloc(FutexQueue) orelse
         return errors.ENOMEM;
     queue.setup(key);
 
-    const state = futexes_lock.lock_irq_disable();
-    defer futexes_lock.unlock_irq_enable(state);
-
-    if (futexes.?.get(key)) |_q| {
-        krn.mm.kfree(queue);
-        return _q;
-    }
     futexes.?.put(key, queue) catch {
         krn.mm.kfree(queue);
         return errors.ENOMEM;
@@ -126,9 +117,9 @@ fn timeoutMs(utime: ?*krn.time.kernel_timespec) !u32 {
 fn cleanupAfterSleep(waiter: *FutexWaiter) bool {
     while (true) {
         const queue = waiter.queue;
-        const lock_state = queue.lock.lock_irq_disable();
+        queue.lock.lock();
         if (queue != waiter.queue) {
-            queue.lock.unlock_irq_enable(lock_state);
+            queue.lock.unlock();
             continue;
         }
         const woken = waiter.woken;
@@ -136,7 +127,7 @@ fn cleanupAfterSleep(waiter: *FutexWaiter) bool {
             waiter.lst.del();
             waiter.lst.setup();
         }
-        queue.lock.unlock_irq_enable(lock_state);
+        queue.lock.unlock();
         return woken;
     }
 }
@@ -227,8 +218,8 @@ fn futexWake(
 
     var woken: u32 = 0;
     {
-        const qstate = queue.lock.lock_irq_disable();
-        defer queue.lock.unlock_irq_enable(qstate);
+        queue.lock.lock();
+        defer queue.lock.unlock();
 
         var it = queue.waiters.iterator();
         _ = it.next();
@@ -246,6 +237,31 @@ fn futexWake(
     }
     return woken;
 }
+
+fn lock_spinlocks(lock1: *krn.Spinlock, lock2: *krn.Spinlock) void {
+    if (@intFromPtr(lock1) == @intFromPtr(lock2)) {
+        lock1.lock();
+    } else if (@intFromPtr(lock1) < @intFromPtr(lock2)) {
+        lock1.lock();
+        lock2.lock();
+    } else {
+        lock2.lock();
+        lock1.lock();
+    }
+}
+
+fn unlock_spinlocks(lock1: *krn.Spinlock, lock2: *krn.Spinlock) void {
+    if (@intFromPtr(lock1) == @intFromPtr(lock2)) {
+        lock1.unlock();
+    } else if (@intFromPtr(lock1) < @intFromPtr(lock2)) {
+        lock2.unlock();
+        lock1.unlock();
+    } else {
+        lock1.unlock();
+        lock2.unlock();
+    }
+}
+
 
 fn futexRequeue(
     uaddr: ?*u32,
@@ -269,10 +285,8 @@ fn futexRequeue(
 
     var woken: u32 = 0;
 
-    const lock_state = src.lock.lock_irq_disable();
-    defer src.lock.unlock_irq_enable(lock_state);
-    if (dst != src) dst.lock.lock();
-    defer if (dst != src) dst.lock.unlock();
+    lock_spinlocks(&src.lock, &dst.lock);
+    defer unlock_spinlocks(&src.lock, &dst.lock);
 
     var it = src.waiters.iterator();
     _ = it.next();

--- a/src/main.zig
+++ b/src/main.zig
@@ -206,13 +206,16 @@ export fn kernel_main(magic: u32, address: u32) noreturn {
     krn.task.init();
     krn.serial.print("[INIT]: Multitasking done\n");
     smp.init();
-    // Get PID1
-    init_userspace();
     krn.serial.print("[INIT]: SMP done\n");
-    fpu.setTaskSwitched();
+
     irq.mapAll();
     krn.jiffies.initTimebase();
     cpu.enableInterrupts();
+
+    // Get PID1
+    init_userspace();
+
+    fpu.setTaskSwitched();
     krn.serial.print("[INIT]: Interrupts are enabled\n");
     dbg.initSymbolTable(&krn.boot_info);
     krn.serial.print("[INIT]: Symbol Table done\n");

--- a/tests/futex.c
+++ b/tests/futex.c
@@ -1,0 +1,553 @@
+/*
+ * futex + pthread test suite
+ *
+ * Covers:
+ *   FUTEX_WAIT
+ *   FUTEX_WAKE
+ *   FUTEX_WAIT EAGAIN
+ *   FUTEX_WAIT timeout
+ *   wake-one
+ *   wake-all
+ *   pthread_join
+ *   pthread_mutex contention
+ *   pthread_cond_signal
+ *   pthread_cond_broadcast
+ *
+ * Build:
+ *   zig cc -target x86-linux-musl -static \
+ *      -o test_futex test_futex.c -lpthread
+ */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <limits.h>
+#include <linux/futex.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+/* ---------------------------------------------------------- */
+/* result tracking                                              */
+/* ---------------------------------------------------------- */
+
+static int g_passed;
+static int g_failed;
+
+static void ok(const char *name)
+{
+    printf("  PASS  %s\n", name);
+    g_passed++;
+}
+
+static void nok(const char *name, const char *why)
+{
+    printf("  FAIL  %s [%s]\n", name, why);
+    g_failed++;
+}
+
+#define CHECK(cond,name,why) \
+    do { if (cond) ok(name); else nok(name,why); } while (0)
+
+/* ---------------------------------------------------------- */
+/* futex helpers                                                */
+/* ---------------------------------------------------------- */
+
+static int futex_wait(int *uaddr, int expected)
+{
+    return syscall(SYS_futex,
+                   uaddr,
+                   FUTEX_WAIT,
+                   expected,
+                   NULL,
+                   NULL,
+                   0);
+}
+
+static int futex_wait_timeout(int *uaddr,
+                              int expected,
+                              const struct timespec *ts)
+{
+    return syscall(SYS_futex,
+                   uaddr,
+                   FUTEX_WAIT,
+                   expected,
+                   ts,
+                   NULL,
+                   0);
+}
+
+static int futex_wake(int *uaddr, int nr)
+{
+    return syscall(SYS_futex,
+                   uaddr,
+                   FUTEX_WAKE,
+                   nr,
+                   NULL,
+                   NULL,
+                   0);
+}
+
+/* ---------------------------------------------------------- */
+/* 1. basic FUTEX_WAIT / FUTEX_WAKE                            */
+/* ---------------------------------------------------------- */
+
+static volatile int fut1;
+static volatile int fut1_woke;
+
+static void *waiter1(void *arg)
+{
+    (void)arg;
+
+    futex_wait((int *)&fut1, 0);
+
+    fut1_woke = 1;
+    return NULL;
+}
+
+static void test_futex_wait_wake(void)
+{
+    puts("\n[ 1. FUTEX_WAIT/FUTEX_WAKE ]");
+
+    fut1 = 0;
+    fut1_woke = 0;
+
+    pthread_t t;
+    pthread_create(&t, NULL, waiter1, NULL);
+
+    usleep(20000);
+
+    fut1 = 1;
+
+    int r = futex_wake((int *)&fut1, 1);
+
+    pthread_join(t, NULL);
+
+    CHECK(r == 1,
+          "wake returns 1",
+          "wrong wake count");
+
+    CHECK(fut1_woke,
+          "waiter resumed",
+          "thread stayed asleep");
+}
+
+/* ---------------------------------------------------------- */
+/* 2. EAGAIN                                                   */
+/* ---------------------------------------------------------- */
+
+static void test_futex_eagain(void)
+{
+    puts("\n[ 2. FUTEX_WAIT EAGAIN ]");
+
+    int fut = 1;
+
+    errno = 0;
+
+    int r = futex_wait(&fut, 0);
+
+    CHECK(r == -1 && errno == EAGAIN,
+          "value mismatch returns EAGAIN",
+          "wrong return");
+}
+
+/* ---------------------------------------------------------- */
+/* 3. timeout                                                  */
+/* ---------------------------------------------------------- */
+
+static void test_futex_timeout(void)
+{
+    puts("\n[ 3. FUTEX_WAIT timeout ]");
+
+    int fut = 0;
+
+    struct timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 50000000;
+
+    errno = 0;
+
+    int r = futex_wait_timeout(&fut, 0, &ts);
+
+    CHECK(r == -1 && errno == ETIMEDOUT,
+          "timeout -> ETIMEDOUT",
+          "wrong result");
+}
+
+/* ---------------------------------------------------------- */
+/* 4. wake one waiter                                          */
+/* ---------------------------------------------------------- */
+
+static volatile int fut4;
+static volatile int wake_one_count;
+
+static void *waiter4(void *arg)
+{
+    (void)arg;
+
+    futex_wait((int *)&fut4, 0);
+
+    __sync_fetch_and_add(&wake_one_count, 1);
+
+    return NULL;
+}
+
+static void test_wake_one(void)
+{
+    puts("\n[ 4. wake one ]");
+
+    pthread_t t1, t2, t3;
+
+    fut4 = 0;
+    wake_one_count = 0;
+
+    pthread_create(&t1, NULL, waiter4, NULL);
+    pthread_create(&t2, NULL, waiter4, NULL);
+    pthread_create(&t3, NULL, waiter4, NULL);
+
+    usleep(20000);
+
+    fut4 = 1;
+
+    int r = futex_wake((int *)&fut4, 1);
+
+    usleep(20000);
+
+    CHECK(r == 1,
+          "wake count == 1",
+          "wrong count");
+
+    CHECK(wake_one_count == 1,
+          "one waiter resumed",
+          "wrong number resumed");
+
+    futex_wake((int *)&fut4, INT_MAX);
+
+    pthread_join(t1,NULL);
+    pthread_join(t2,NULL);
+    pthread_join(t3,NULL);
+}
+
+/* ---------------------------------------------------------- */
+/* 5. wake all                                                 */
+/* ---------------------------------------------------------- */
+
+static volatile int fut5;
+static volatile int wake_all_count;
+
+static void *waiter5(void *arg)
+{
+    (void)arg;
+
+    futex_wait((int *)&fut5, 0);
+
+    __sync_fetch_and_add(&wake_all_count, 1);
+
+    return NULL;
+}
+
+static void test_wake_all(void)
+{
+    puts("\n[ 5. wake all ]");
+
+    pthread_t t1, t2, t3;
+
+    fut5 = 0;
+    wake_all_count = 0;
+
+    pthread_create(&t1,NULL,waiter5,NULL);
+    pthread_create(&t2,NULL,waiter5,NULL);
+    pthread_create(&t3,NULL,waiter5,NULL);
+
+    usleep(20000);
+
+    fut5 = 1;
+
+    int r = futex_wake((int *)&fut5, INT_MAX);
+
+    pthread_join(t1,NULL);
+    pthread_join(t2,NULL);
+    pthread_join(t3,NULL);
+
+    CHECK(r == 3,
+          "wake-all reports 3",
+          "wrong wake count");
+
+    CHECK(wake_all_count == 3,
+          "all waiters resumed",
+          "not all resumed");
+}
+
+/* ---------------------------------------------------------- */
+/* 6. pthread_join                                             */
+/* ---------------------------------------------------------- */
+
+static void *join_worker(void *arg)
+{
+    (void)arg;
+    return (void *)0x1234;
+}
+
+static void test_pthread_join(void)
+{
+    puts("\n[ 6. pthread_join ]");
+
+    pthread_t t;
+
+    pthread_create(&t,NULL,join_worker,NULL);
+
+    void *ret = NULL;
+
+    int r = pthread_join(t,&ret);
+
+    CHECK(r == 0,
+          "pthread_join succeeds",
+          "join failed");
+
+    CHECK(ret == (void *)0x1234,
+          "return value preserved",
+          "wrong retval");
+}
+
+/* ---------------------------------------------------------- */
+/* 7. mutex contention                                         */
+/* ---------------------------------------------------------- */
+
+static pthread_mutex_t mtx =
+    PTHREAD_MUTEX_INITIALIZER;
+
+static volatile int mutex_seen;
+
+static void *mutex_thread(void *arg)
+{
+    (void)arg;
+
+    pthread_mutex_lock(&mtx);
+
+    mutex_seen = 1;
+
+    pthread_mutex_unlock(&mtx);
+
+    return NULL;
+}
+
+static void test_mutex_contention(void)
+{
+    puts("\n[ 7. pthread_mutex ]");
+
+    mutex_seen = 0;
+
+    pthread_mutex_lock(&mtx);
+
+    pthread_t t;
+    pthread_create(&t,NULL,mutex_thread,NULL);
+
+    usleep(20000);
+
+    CHECK(!mutex_seen,
+          "thread blocked on mutex",
+          "lock did not block");
+
+    pthread_mutex_unlock(&mtx);
+
+    pthread_join(t,NULL);
+
+    CHECK(mutex_seen,
+          "thread acquires after unlock",
+          "never acquired");
+}
+
+/* ---------------------------------------------------------- */
+/* 8. cond signal                                              */
+/* ---------------------------------------------------------- */
+
+static pthread_mutex_t cv_mtx =
+    PTHREAD_MUTEX_INITIALIZER;
+
+static pthread_cond_t cv =
+    PTHREAD_COND_INITIALIZER;
+
+static volatile int cv_ready;
+static volatile int cv_seen;
+
+static void *cv_waiter(void *arg)
+{
+    (void)arg;
+
+    pthread_mutex_lock(&cv_mtx);
+
+    while (!cv_ready)
+        pthread_cond_wait(&cv, &cv_mtx);
+
+    cv_seen = 1;
+
+    pthread_mutex_unlock(&cv_mtx);
+
+    return NULL;
+}
+
+static void test_cond_signal(void)
+{
+    puts("\n[ 8. pthread_cond_signal ]");
+
+    cv_ready = 0;
+    cv_seen = 0;
+
+    pthread_t t;
+    pthread_create(&t,NULL,cv_waiter,NULL);
+
+    usleep(20000);
+
+    pthread_mutex_lock(&cv_mtx);
+
+    cv_ready = 1;
+
+    pthread_cond_signal(&cv);
+
+    pthread_mutex_unlock(&cv_mtx);
+
+    pthread_join(t,NULL);
+
+    CHECK(cv_seen,
+          "cond signal wakes waiter",
+          "waiter never resumed");
+}
+
+/* ---------------------------------------------------------- */
+/* 9. cond broadcast                                           */
+/* ---------------------------------------------------------- */
+
+static volatile int bc_ready;
+static volatile int bc_count;
+
+static void *bc_waiter(void *arg)
+{
+    (void)arg;
+
+    pthread_mutex_lock(&cv_mtx);
+
+    while (!bc_ready)
+        pthread_cond_wait(&cv, &cv_mtx);
+
+    __sync_fetch_and_add(&bc_count,1);
+
+    pthread_mutex_unlock(&cv_mtx);
+
+    return NULL;
+}
+
+static void test_cond_broadcast(void)
+{
+    puts("\n[ 9. pthread_cond_broadcast ]");
+
+    bc_ready = 0;
+    bc_count = 0;
+
+    pthread_t t1,t2,t3;
+
+    pthread_create(&t1,NULL,bc_waiter,NULL);
+    pthread_create(&t2,NULL,bc_waiter,NULL);
+    pthread_create(&t3,NULL,bc_waiter,NULL);
+
+    usleep(20000);
+
+    pthread_mutex_lock(&cv_mtx);
+
+    bc_ready = 1;
+
+    pthread_cond_broadcast(&cv);
+
+    pthread_mutex_unlock(&cv_mtx);
+
+    pthread_join(t1,NULL);
+    pthread_join(t2,NULL);
+    pthread_join(t3,NULL);
+
+    CHECK(bc_count == 3,
+          "broadcast wakes all waiters",
+          "not all resumed");
+}
+
+/* ---------------------------------------------------------- */
+/* 10. ping-pong stress                                        */
+/* ---------------------------------------------------------- */
+
+static volatile int ping;
+static volatile int pong;
+
+static void *pong_thread(void *arg)
+{
+    (void)arg;
+
+    for (int i = 0; i < 1000; i++) {
+
+        while (!ping)
+            futex_wait((int *)&ping, 0);
+
+        ping = 0;
+
+        pong = 1;
+        futex_wake((int *)&pong, 1);
+    }
+
+    return NULL;
+}
+
+static void test_ping_pong(void)
+{
+    puts("\n[ 10. ping-pong stress ]");
+
+    ping = 0;
+    pong = 0;
+
+    pthread_t t;
+    pthread_create(&t,NULL,pong_thread,NULL);
+
+    for (int i = 0; i < 1000; i++) {
+
+        ping = 1;
+        futex_wake((int *)&ping, 1);
+
+        while (!pong)
+            futex_wait((int *)&pong, 0);
+
+        pong = 0;
+    }
+
+    pthread_join(t,NULL);
+
+    CHECK(1,
+          "1000 ping-pong iterations completed",
+          "unexpected failure");
+}
+
+/* ---------------------------------------------------------- */
+/* main                                                        */
+/* ---------------------------------------------------------- */
+
+int main(void)
+{
+    puts("=== futex test suite ===");
+
+    test_futex_wait_wake();
+    test_futex_eagain();
+    test_futex_timeout();
+    test_wake_one();
+    test_wake_all();
+    test_pthread_join();
+    test_mutex_contention();
+    test_cond_signal();
+    test_cond_broadcast();
+    test_ping_pong();
+
+    printf("\n=== %d passed, %d failed ===\n",
+           g_passed,
+           g_failed);
+
+    return g_failed ? 1 : 0;
+}
+

--- a/tests/signals.c
+++ b/tests/signals.c
@@ -1,0 +1,1428 @@
+/*
+ * signal test suite
+ *
+ * Covers: sigaction, sigprocmask, sigpending, sigreturn (mask restore),
+ *         SA_NODEFER, SA_RESETHAND, SA_SIGINFO, sa_mask, sigsuspend,
+ *         pthread_kill, pthread_sigmask, thread-masked signal delivery,
+ *         exit / exit_group, SIGCHLD, WIFSIGNALED.
+ *
+ * Build:
+ *   zig cc -target x86-linux-musl -static -o test_signals test_signals.c -lpthread
+ */
+
+#define _GNU_SOURCE
+
+#include <signal.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <time.h>
+#include <sys/wait.h>
+#include <sys/syscall.h>
+#include <pthread.h>
+
+/* x86 32-bit syscall numbers (in case sys/syscall.h is incomplete) */
+#ifndef SYS_exit
+#define SYS_exit       1
+#endif
+#ifndef SYS_exit_group
+#define SYS_exit_group 252
+#endif
+#ifndef SYS_gettid
+#define SYS_gettid    224
+#endif
+#ifndef SYS_tkill
+#define SYS_tkill     238
+#endif
+
+/* Signal sent via tkill that asks a worker thread to exit itself via SYS_exit.
+ * We can't just send SIGKILL because in our kernel SIGKILL's default action
+ * exits the whole thread group. Instead each worker installs a handler for
+ * this signal that calls SYS_exit (raw, per-thread). pthread_join would need
+ * futexes (not implemented) so this is how we tear workers down. */
+#define SIG_TKILL_EXIT  SIGTERM
+
+static void tkill_exit_handler(int s) {
+    (void)s;
+    syscall(SYS_exit, 0);
+}
+
+static void install_tkill_exit_handler(void)
+{
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = tkill_exit_handler;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIG_TKILL_EXIT, &sa, NULL);
+}
+
+static int tkill_thread(pid_t tid)
+{
+    return syscall(SYS_tkill, tid, SIG_TKILL_EXIT);
+}
+
+/* ------------------------------------------------------------------ */
+/* Result tracking                                                      */
+/* ------------------------------------------------------------------ */
+
+static int g_passed = 0;
+static int g_failed = 0;
+
+static void ok(const char *name)
+{
+    printf("  PASS  %s\n", name);
+    g_passed++;
+}
+
+static void nok(const char *name, const char *why)
+{
+    printf("  FAIL  %s  [%s]\n", name, why);
+    g_failed++;
+}
+
+#define CHECK(cond, name, why) \
+    do { if ((cond)) ok(name); else nok(name, why); } while (0)
+
+/* ------------------------------------------------------------------ */
+/* Helper: reset SIGUSR1 / SIGUSR2 to SIG_DFL, fully unblocked        */
+/* ------------------------------------------------------------------ */
+
+static void reset_usr(void)
+{
+    struct sigaction dfl;
+    memset(&dfl, 0, sizeof dfl);
+    dfl.sa_handler = SIG_DFL;
+    sigemptyset(&dfl.sa_mask);
+    sigaction(SIGUSR1, &dfl, NULL);
+    sigaction(SIGUSR2, &dfl, NULL);
+
+    sigset_t u;
+    sigemptyset(&u);
+    sigaddset(&u, SIGUSR1);
+    sigaddset(&u, SIGUSR2);
+    pthread_sigmask(SIG_UNBLOCK, &u, NULL);
+}
+
+/* ================================================================== */
+/* 1. Basic sigaction install and delivery                              */
+/* ================================================================== */
+
+static volatile sig_atomic_t basic_fired;
+static void basic_handler(int s) { (void)s; basic_fired = 1; }
+
+static void test_basic_sigaction(void)
+{
+    puts("\n[ 1. basic sigaction ]");
+    reset_usr();
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = basic_handler;
+    sigemptyset(&sa.sa_mask);
+
+    CHECK(sigaction(SIGUSR1, &sa, NULL) == 0,
+          "sigaction install returns 0", "call failed");
+
+    basic_fired = 0;
+    raise(SIGUSR1);
+    CHECK(basic_fired, "handler called", "not called");
+
+    struct sigaction got;
+    sigaction(SIGUSR1, NULL, &got);
+    CHECK(got.sa_handler == basic_handler,
+          "sigaction GET returns installed handler", "wrong pointer");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 2. SA_RESETHAND                                                      */
+/* ================================================================== */
+
+static volatile sig_atomic_t rh_count;
+static void rh_handler(int s) { (void)s; rh_count++; }
+
+static void test_sa_resethand(void)
+{
+    puts("\n[ 2. SA_RESETHAND ]");
+    reset_usr();
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = rh_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESETHAND;
+    sigaction(SIGUSR1, &sa, NULL);
+
+    rh_count = 0;
+    raise(SIGUSR1);
+    CHECK(rh_count == 1, "handler called exactly once", "wrong count");
+
+    struct sigaction after;
+    sigaction(SIGUSR1, NULL, &after);
+    CHECK(after.sa_handler == SIG_DFL,
+          "disposition reset to SIG_DFL", "not SIG_DFL");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 3. SA_NODEFER — recursive re-entry vs. default defer                */
+/* ================================================================== */
+
+static volatile sig_atomic_t nd_depth;
+static volatile sig_atomic_t nd_max;
+
+static void nd_handler(int s)
+{
+    (void)s;
+    nd_depth++;
+    if (nd_depth > nd_max) nd_max = nd_depth;
+    if (nd_depth < 3) raise(SIGUSR1);
+    nd_depth--;
+}
+
+static volatile sig_atomic_t df_depth;
+static volatile sig_atomic_t df_max;
+static volatile sig_atomic_t df_calls;
+
+static void df_handler(int s)
+{
+    (void)s;
+    df_calls++;
+    df_depth++;
+    if (df_depth > df_max) df_max = df_depth;
+    /* raise only on the first call: without SA_NODEFER the signal is queued,
+       not re-entered, so depth stays 1; a second raise would loop forever */
+    if (df_depth < 3 && df_calls == 1)
+        raise(SIGUSR1);
+    df_depth--;
+}
+
+static void test_sa_nodefer(void)
+{
+    puts("\n[ 3. SA_NODEFER ]");
+    reset_usr();
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = nd_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_NODEFER;
+    sigaction(SIGUSR1, &sa, NULL);
+
+    nd_depth = nd_max = 0;
+    raise(SIGUSR1);
+    CHECK(nd_max >= 2,
+          "SA_NODEFER: recursive delivery (depth >= 2)", "no recursion");
+
+    reset_usr();
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = df_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGUSR1, &sa, NULL);
+
+    df_depth = df_max = df_calls = 0;
+    raise(SIGUSR1);
+    CHECK(df_max == 1,
+          "without SA_NODEFER: no recursion (depth stays 1)", "unexpected recursion");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 4. SA_SIGINFO — three-argument handler                              */
+/* ================================================================== */
+
+static volatile sig_atomic_t si_signo;
+static volatile sig_atomic_t si_called;
+
+static void si_handler(int s, siginfo_t *info, void *ctx)
+{
+    (void)s; (void)ctx;
+    si_signo  = info->si_signo;
+    si_called = 1;
+}
+
+static void test_sa_siginfo(void)
+{
+    puts("\n[ 4. SA_SIGINFO ]");
+    reset_usr();
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_sigaction = si_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_SIGINFO;
+    sigaction(SIGUSR2, &sa, NULL);
+
+    si_called = si_signo = 0;
+    raise(SIGUSR2);
+    CHECK(si_called, "handler called", "not called");
+    CHECK(si_signo == SIGUSR2, "si_signo correct", "wrong signo");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 5. SIG_BLOCK prevents delivery; SIG_UNBLOCK releases pending        */
+/* ================================================================== */
+
+static volatile sig_atomic_t blk_fired;
+static void blk_handler(int s) { (void)s; blk_fired = 1; }
+
+static void test_sigprocmask_block(void)
+{
+    puts("\n[ 5. SIG_BLOCK / SIG_UNBLOCK ]");
+    reset_usr();
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = blk_handler;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR1, &sa, NULL);
+
+    sigset_t blk;
+    sigemptyset(&blk);
+    sigaddset(&blk, SIGUSR1);
+    sigprocmask(SIG_BLOCK, &blk, NULL);
+
+    blk_fired = 0;
+    raise(SIGUSR1);
+    CHECK(!blk_fired, "SIG_BLOCK: not delivered while blocked", "fired while blocked");
+
+    sigprocmask(SIG_UNBLOCK, &blk, NULL);
+    CHECK(blk_fired, "SIG_UNBLOCK: pending delivered on unblock", "not delivered");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 6. sigpending reports blocked+raised signals                         */
+/* ================================================================== */
+
+static void test_sigpending(void)
+{
+    puts("\n[ 6. sigpending ]");
+    reset_usr();
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = blk_handler;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR1, &sa, NULL);
+
+    sigset_t blk;
+    sigemptyset(&blk);
+    sigaddset(&blk, SIGUSR1);
+    sigprocmask(SIG_BLOCK, &blk, NULL);
+
+    blk_fired = 0;
+    raise(SIGUSR1);
+
+    sigset_t pend;
+    sigemptyset(&pend);
+    sigpending(&pend);
+    CHECK(sigismember(&pend, SIGUSR1),
+          "sigpending: blocked+raised signal is pending", "not in set");
+
+    sigprocmask(SIG_UNBLOCK, &blk, NULL);
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 7. sigreturn restores the pre-handler sigmask                        */
+/* ================================================================== */
+
+static volatile sig_atomic_t restore_ok; /* 1=pass -1=fail */
+
+static void restore_handler(int s)
+{
+    (void)s;
+    /* SIGUSR2 was blocked before this handler — must still be blocked */
+    sigset_t cur;
+    sigprocmask(SIG_BLOCK, NULL, &cur);
+    restore_ok = sigismember(&cur, SIGUSR2) ? 1 : -1;
+}
+
+static void test_sigreturn_mask_restore(void)
+{
+    puts("\n[ 7. sigreturn: mask restored ]");
+    reset_usr();
+
+    sigset_t blk;
+    sigemptyset(&blk);
+    sigaddset(&blk, SIGUSR2);
+    sigprocmask(SIG_BLOCK, &blk, NULL);
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = restore_handler;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR1, &sa, NULL);
+
+    restore_ok = 0;
+    raise(SIGUSR1);
+    CHECK(restore_ok == 1,
+          "in handler: pre-blocked SIGUSR2 still blocked", "not blocked in handler");
+
+    sigset_t after;
+    sigprocmask(SIG_BLOCK, NULL, &after);
+    CHECK(sigismember(&after, SIGUSR2),
+          "after handler: sigmask restored by sigreturn", "not restored");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 8. sa_mask blocks extra signals during handler                       */
+/* ================================================================== */
+
+static volatile sig_atomic_t sa_mask_pending_in_handler;
+static volatile sig_atomic_t sa_mask_u2_fired;
+
+static void sa_mask_u2_handler(int s) { (void)s; sa_mask_u2_fired = 1; }
+
+static void sa_mask_u1_handler(int s)
+{
+    (void)s;
+    raise(SIGUSR2);          /* blocked by sa_mask → goes to pending */
+    sigset_t p;
+    sigemptyset(&p);
+    sigpending(&p);
+    sa_mask_pending_in_handler = sigismember(&p, SIGUSR2) ? 1 : 0;
+}
+
+static void test_sa_mask(void)
+{
+    puts("\n[ 8. sa_mask ]");
+    reset_usr();
+
+    struct sigaction sa2;
+    memset(&sa2, 0, sizeof sa2);
+    sa2.sa_handler = sa_mask_u2_handler;
+    sigemptyset(&sa2.sa_mask);
+    sigaction(SIGUSR2, &sa2, NULL);
+
+    struct sigaction sa1;
+    memset(&sa1, 0, sizeof sa1);
+    sa1.sa_handler = sa_mask_u1_handler;
+    sigemptyset(&sa1.sa_mask);
+    sigaddset(&sa1.sa_mask, SIGUSR2);  /* block SIGUSR2 while in SIGUSR1 handler */
+    sigaction(SIGUSR1, &sa1, NULL);
+
+    sa_mask_pending_in_handler = 0;
+    sa_mask_u2_fired = 0;
+    raise(SIGUSR1);
+
+    CHECK(sa_mask_pending_in_handler,
+          "sa_mask: SIGUSR2 pending inside SIGUSR1 handler", "not blocked by sa_mask");
+    CHECK(sa_mask_u2_fired,
+          "sa_mask: SIGUSR2 delivered after SIGUSR1 handler returns", "never delivered");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 9. Signal implicitly blocked during its own handler (no SA_NODEFER) */
+/* ================================================================== */
+
+static volatile sig_atomic_t self_blk_ok; /* 1=pass -1=fail */
+
+static void self_blk_handler(int s)
+{
+    (void)s;
+    sigset_t cur;
+    sigprocmask(SIG_BLOCK, NULL, &cur);
+    self_blk_ok = sigismember(&cur, SIGUSR1) ? 1 : -1;
+}
+
+static void test_signal_self_masked(void)
+{
+    puts("\n[ 9. signal blocked during own handler ]");
+    reset_usr();
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = self_blk_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGUSR1, &sa, NULL);
+
+    self_blk_ok = 0;
+    raise(SIGUSR1);
+    CHECK(self_blk_ok == 1,
+          "SIGUSR1 blocked inside its own handler", "not blocked");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 10. Multiple signals pending → all delivered after unblock           */
+/* ================================================================== */
+
+static volatile sig_atomic_t multi_u1;
+static volatile sig_atomic_t multi_u2;
+static void multi_u1_h(int s) { (void)s; multi_u1 = 1; }
+static void multi_u2_h(int s) { (void)s; multi_u2 = 1; }
+
+static void test_multiple_pending(void)
+{
+    puts("\n[ 10. multiple signals pending ]");
+    reset_usr();
+
+    struct sigaction sa1, sa2;
+    memset(&sa1, 0, sizeof sa1); sa1.sa_handler = multi_u1_h; sigemptyset(&sa1.sa_mask);
+    memset(&sa2, 0, sizeof sa2); sa2.sa_handler = multi_u2_h; sigemptyset(&sa2.sa_mask);
+    sigaction(SIGUSR1, &sa1, NULL);
+    sigaction(SIGUSR2, &sa2, NULL);
+
+    sigset_t blk;
+    sigemptyset(&blk);
+    sigaddset(&blk, SIGUSR1);
+    sigaddset(&blk, SIGUSR2);
+    sigprocmask(SIG_BLOCK, &blk, NULL);
+
+    multi_u1 = multi_u2 = 0;
+    raise(SIGUSR1);
+    raise(SIGUSR2);
+
+    sigset_t pend;
+    sigpending(&pend);
+    CHECK(sigismember(&pend, SIGUSR1) && sigismember(&pend, SIGUSR2),
+          "both signals in pending set", "not both pending");
+
+    sigprocmask(SIG_UNBLOCK, &blk, NULL);
+    CHECK(multi_u1 && multi_u2,
+          "both handlers called after unblock", "not both delivered");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 11. SIGKILL and SIGSTOP cannot be caught                            */
+/* ================================================================== */
+
+static void uncatch_h(int s) { (void)s; }
+
+static void test_uncatchable(void)
+{
+    puts("\n[ 11. SIGKILL/SIGSTOP uncatchable ]");
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = uncatch_h;
+    sigemptyset(&sa.sa_mask);
+
+    CHECK(sigaction(SIGKILL, &sa, NULL) == -1 && errno == EINVAL,
+          "sigaction(SIGKILL) → EINVAL", "not rejected");
+    CHECK(sigaction(SIGSTOP, &sa, NULL) == -1 && errno == EINVAL,
+          "sigaction(SIGSTOP) → EINVAL", "not rejected");
+}
+
+/* ================================================================== */
+/* 12. SIG_SETMASK replaces full mask; old mask returned               */
+/* ================================================================== */
+
+static volatile sig_atomic_t setmask_fired;
+static void setmask_h(int s) { (void)s; setmask_fired = 1; }
+
+static void test_sigprocmask_setmask(void)
+{
+    puts("\n[ 12. SIG_SETMASK ]");
+    reset_usr();
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = setmask_h;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR1, &sa, NULL);
+
+    sigset_t full;
+    sigemptyset(&full);
+    sigaddset(&full, SIGUSR1);
+    sigaddset(&full, SIGUSR2);
+    sigprocmask(SIG_SETMASK, &full, NULL);
+
+    setmask_fired = 0;
+    raise(SIGUSR1);
+    CHECK(!setmask_fired, "SIG_SETMASK blocks signal", "fired while blocked");
+
+    sigset_t empty, old;
+    sigemptyset(&empty);
+    sigprocmask(SIG_SETMASK, &empty, &old);
+
+    CHECK(sigismember(&old, SIGUSR1) && sigismember(&old, SIGUSR2),
+          "SIG_SETMASK: old mask returned correctly", "wrong old mask");
+    CHECK(setmask_fired,
+          "SIG_SETMASK to empty: pending delivered", "not delivered");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 13. sigsuspend atomically waits (fork + kill)                       */
+/* ================================================================== */
+
+static volatile sig_atomic_t susp_fired;
+static void susp_h(int s) { (void)s; susp_fired = 1; }
+
+static void test_sigsuspend(void)
+{
+    puts("\n[ 13. sigsuspend ]");
+    reset_usr();
+
+    sigset_t blk;
+    sigemptyset(&blk);
+    sigaddset(&blk, SIGUSR1);
+    sigprocmask(SIG_BLOCK, &blk, NULL);
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = susp_h;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR1, &sa, NULL);
+
+    pid_t child = fork();
+    if (child == 0) {
+        usleep(20000);
+        kill(getppid(), SIGUSR1);
+        _exit(0);
+    }
+
+    susp_fired = 0;
+    sigset_t wait_mask;
+    sigemptyset(&wait_mask);
+    int ret = sigsuspend(&wait_mask);
+    int saved_errno = errno;
+    waitpid(child, NULL, 0);
+
+    CHECK(ret == -1 && saved_errno == EINTR,
+          "sigsuspend returns -1/EINTR", "wrong return");
+    CHECK(susp_fired, "handler called on wakeup", "not called");
+
+    sigset_t after;
+    sigprocmask(SIG_BLOCK, NULL, &after);
+    CHECK(sigismember(&after, SIGUSR1),
+          "original mask restored after sigsuspend", "mask not restored");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 14. SA_NODEFER + SA_SIGINFO combined                                */
+/* ================================================================== */
+
+static volatile sig_atomic_t nd_si_depth;
+static volatile sig_atomic_t nd_si_signo;
+
+static void nd_si_handler(int s, siginfo_t *info, void *ctx)
+{
+    (void)s; (void)ctx;
+    nd_si_depth++;
+    nd_si_signo = info->si_signo;
+    if (nd_si_depth < 2) raise(SIGUSR2);
+    nd_si_depth--;
+}
+
+static void test_nodefer_siginfo(void)
+{
+    puts("\n[ 14. SA_NODEFER + SA_SIGINFO ]");
+    reset_usr();
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_sigaction = nd_si_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_NODEFER | SA_SIGINFO;
+    sigaction(SIGUSR2, &sa, NULL);
+
+    nd_si_depth = nd_si_signo = 0;
+    raise(SIGUSR2);
+    CHECK(nd_si_signo == SIGUSR2, "si_signo correct", "wrong signo");
+    CHECK(nd_si_depth == 0, "recursive delivery + clean unwind", "depth mismatch");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 15. SIG_IGN                                                          */
+/* ================================================================== */
+
+static volatile sig_atomic_t ign_fired;
+static void ign_probe_h(int s) { (void)s; ign_fired = 1; }
+
+static void test_sig_ign(void)
+{
+    puts("\n[ 15. SIG_IGN ]");
+    reset_usr();
+
+    struct sigaction sa_ign;
+    memset(&sa_ign, 0, sizeof sa_ign);
+    sa_ign.sa_handler = SIG_IGN;
+    sigemptyset(&sa_ign.sa_mask);
+    sigaction(SIGUSR1, &sa_ign, NULL);
+
+    ign_fired = 0;
+    raise(SIGUSR1);
+    CHECK(!ign_fired, "SIG_IGN: signal discarded", "handler fired");
+
+    struct sigaction sa_real;
+    memset(&sa_real, 0, sizeof sa_real);
+    sa_real.sa_handler = ign_probe_h;
+    sigemptyset(&sa_real.sa_mask);
+    sigaction(SIGUSR1, &sa_real, NULL);
+    raise(SIGUSR1);
+    CHECK(ign_fired, "after removing SIG_IGN: handler fires", "not called");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 16. pthread_kill — signal targeted at a specific thread             */
+/* ================================================================== */
+
+static volatile pid_t pkill_worker_tid;
+static volatile sig_atomic_t pkill_fired;
+static void pkill_h(int s) { (void)s; pkill_fired = 1; }
+
+static void *pkill_thread(void *arg)
+{
+    (void)arg;
+    pkill_worker_tid = syscall(SYS_gettid);
+    /* unblock SIGUSR1 in this thread */
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGUSR1);
+    pthread_sigmask(SIG_UNBLOCK, &set, NULL);
+
+    /* spin until killed via tkill (no pthread_exit / no futex needed) */
+    while (1)
+        usleep(10000);
+    return NULL;
+}
+
+static void test_pthread_kill(void)
+{
+    puts("\n[ 16. pthread_kill ]");
+    reset_usr();
+
+    /* main thread blocks SIGUSR1 so only the target thread can receive it */
+    sigset_t blk;
+    sigemptyset(&blk);
+    sigaddset(&blk, SIGUSR1);
+    pthread_sigmask(SIG_BLOCK, &blk, NULL);
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = pkill_h;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR1, &sa, NULL);
+
+    pkill_fired = 0;
+    pkill_worker_tid = 0;
+    pthread_t t;
+    pthread_create(&t, NULL, pkill_thread, NULL);
+
+    /* wait until worker has captured its TID and unblocked SIGUSR1 */
+    while (!pkill_worker_tid) usleep(1000);
+    usleep(5000);
+
+    pthread_kill(t, SIGUSR1);
+
+    for (int i = 0; i < 1000 && !pkill_fired; i++) usleep(1000);
+    CHECK(pkill_fired, "pthread_kill: handler fired in target thread", "not fired");
+
+    tkill_thread(pkill_worker_tid);
+    usleep(10000);
+
+    pthread_sigmask(SIG_UNBLOCK, &blk, NULL);
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 17. pthread_sigmask is per-thread (does not affect other threads)   */
+/* ================================================================== */
+
+/* pipe[0]=read pipe[1]=write used as a barrier */
+static int barrier_pipe[2];
+static volatile pid_t mask_block_tid;
+
+static void *mask_block_thread(void *arg)
+{
+    (void)arg;
+    mask_block_tid = syscall(SYS_gettid);
+    /* block SIGUSR1 only in this thread */
+    sigset_t blk;
+    sigemptyset(&blk);
+    sigaddset(&blk, SIGUSR1);
+    pthread_sigmask(SIG_BLOCK, &blk, NULL);
+
+    /* tell main we're done */
+    write(barrier_pipe[1], "x", 1);
+
+    /* spin until killed via tkill */
+    while (1) usleep(10000);
+    return NULL;
+}
+
+static void test_thread_sigmask_independent(void)
+{
+    puts("\n[ 17. pthread_sigmask independent per thread ]");
+    reset_usr();
+
+    pipe(barrier_pipe);
+
+    mask_block_tid = 0;
+    pthread_t t;
+    pthread_create(&t, NULL, mask_block_thread, NULL);
+
+    /* wait until thread has blocked SIGUSR1 in itself */
+    char buf;
+    read(barrier_pipe[0], &buf, 1);
+
+    /* check main thread — SIGUSR1 must NOT be blocked here */
+    sigset_t main_mask;
+    pthread_sigmask(SIG_BLOCK, NULL, &main_mask);
+    CHECK(!sigismember(&main_mask, SIGUSR1),
+          "thread's SIG_BLOCK does not affect main thread mask",
+          "SIGUSR1 unexpectedly blocked in main");
+
+    tkill_thread(mask_block_tid);
+    usleep(10000);
+    close(barrier_pipe[0]);
+    close(barrier_pipe[1]);
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 18. Process-directed signal goes to the thread that has it unblocked*/
+/* ================================================================== */
+
+static volatile pid_t proc_sig_tid;
+static volatile sig_atomic_t proc_sig_fired;
+static void proc_sig_h(int s) { (void)s; proc_sig_fired = 1; }
+
+static void *proc_sig_thread(void *arg)
+{
+    (void)arg;
+    proc_sig_tid = syscall(SYS_gettid);
+    /* unblock SIGUSR2 in this thread (main keeps it blocked) */
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGUSR2);
+    pthread_sigmask(SIG_UNBLOCK, &set, NULL);
+
+    while (1)
+        usleep(10000);
+    return NULL;
+}
+
+static void test_process_signal_to_unblocked_thread(void)
+{
+    puts("\n[ 18. process signal delivered to unblocked thread ]");
+    reset_usr();
+
+    /* block SIGUSR2 in main */
+    sigset_t blk;
+    sigemptyset(&blk);
+    sigaddset(&blk, SIGUSR2);
+    pthread_sigmask(SIG_BLOCK, &blk, NULL);
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = proc_sig_h;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR2, &sa, NULL);
+
+    proc_sig_fired = 0;
+    proc_sig_tid = 0;
+    pthread_t t;
+    pthread_create(&t, NULL, proc_sig_thread, NULL);
+
+    while (!proc_sig_tid) usleep(1000);
+    usleep(5000);  /* let it finish unblocking */
+
+    kill(getpid(), SIGUSR2);   /* process-directed */
+
+    for (int i = 0; i < 1000 && !proc_sig_fired; i++) usleep(1000);
+    CHECK(proc_sig_fired,
+          "process kill: delivered to unblocked thread",
+          "signal not received");
+
+    tkill_thread(proc_sig_tid);
+    usleep(10000);
+
+    pthread_sigmask(SIG_UNBLOCK, &blk, NULL);
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 19. Thread-masked signal stays pending until thread unblocks it     */
+/* ================================================================== */
+
+static volatile pid_t thread_pend_tid;
+static volatile sig_atomic_t thread_pend_fired;
+static void thread_pend_h(int s) { (void)s; thread_pend_fired = 1; }
+
+/* pipe: [0]=read [1]=write */
+static int tp_pipe[2];
+
+static void *thread_pending_fn(void *arg)
+{
+    (void)arg;
+    thread_pend_tid = syscall(SYS_gettid);
+    /* block SIGUSR1 in this thread */
+    sigset_t blk;
+    sigemptyset(&blk);
+    sigaddset(&blk, SIGUSR1);
+    pthread_sigmask(SIG_BLOCK, &blk, NULL);
+
+    /* ready: tell main */
+    write(tp_pipe[1], "r", 1);
+
+    /* wait for main to send signal and confirm */
+    char buf;
+    read(tp_pipe[0], &buf, 1);
+
+    /* check signal is pending */
+    sigset_t pend;
+    sigpending(&pend);
+    int was_pending = sigismember(&pend, SIGUSR1);
+
+    /* unblock — should be delivered now */
+    pthread_sigmask(SIG_UNBLOCK, &blk, NULL);
+
+    /* tell main: was_pending result + fired result */
+    buf = was_pending ? 'p' : 'n';
+    write(tp_pipe[1], &buf, 1);
+
+    /* spin until killed via tkill */
+    while (1) usleep(10000);
+    return NULL;
+}
+
+static void test_thread_masked_pending(void)
+{
+    puts("\n[ 19. thread-masked signal pending until unblocked ]");
+    reset_usr();
+
+    pipe(tp_pipe);
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = thread_pend_h;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR1, &sa, NULL);
+
+    thread_pend_fired = 0;
+    thread_pend_tid = 0;
+    pthread_t t;
+    pthread_create(&t, NULL, thread_pending_fn, NULL);
+
+    /* wait until thread is ready (blocking SIGUSR1) */
+    char buf;
+    read(tp_pipe[0], &buf, 1);
+
+    /* direct signal at the thread */
+    pthread_kill(t, SIGUSR1);
+
+    /* give kernel a moment, then tell thread to check pending */
+    usleep(5000);
+    write(tp_pipe[1], "c", 1);
+
+    /* read thread's pending-check result */
+    read(tp_pipe[0], &buf, 1);
+    CHECK(buf == 'p',
+          "thread-masked: signal pending inside masked thread",
+          "signal not pending");
+
+    /* give the thread time to deliver the now-unblocked signal */
+    for (int i = 0; i < 1000 && !thread_pend_fired; i++) usleep(1000);
+    CHECK(thread_pend_fired,
+          "thread-masked: signal delivered on unblock",
+          "not delivered after unblock");
+
+    tkill_thread(thread_pend_tid);
+    usleep(10000);
+
+    close(tp_pipe[0]);
+    close(tp_pipe[1]);
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 20. exit() — exit code seen by parent via waitpid                   */
+/* ================================================================== */
+
+static void test_exit_code(void)
+{
+    puts("\n[ 20. exit code ]");
+
+    pid_t child = fork();
+    if (child == 0) {
+        exit(42);
+    }
+    int status = 0;
+    waitpid(child, &status, 0);
+    CHECK(WIFEXITED(status), "child exited normally", "not normal exit");
+    CHECK(WEXITSTATUS(status) == 42,
+          "exit code 42 seen by parent", "wrong exit code");
+}
+
+/* ================================================================== */
+/* 21. exit_group terminates all threads in the group                  */
+/* ================================================================== */
+
+static void *spin_thread(void *arg)
+{
+    (void)arg;
+    while (1) usleep(10000);   /* spins until killed by exit_group */
+    return NULL;
+}
+
+static void test_exit_group(void)
+{
+    puts("\n[ 21. exit_group kills all threads ]");
+
+    pid_t child = fork();
+    if (child == 0) {
+        pthread_t t;
+        pthread_create(&t, NULL, spin_thread, NULL);
+        usleep(5000);                    /* give thread time to start */
+        syscall(SYS_exit_group, 55);
+        _exit(99);                       /* not reached */
+    }
+
+    /* parent polls for child exit (max ~2 s) */
+    int status = 0;
+    int exited = 0;
+    for (int i = 0; i < 200; i++) {
+        pid_t r = waitpid(child, &status, WNOHANG);
+        if (r == child) { exited = 1; break; }
+        usleep(10000);
+    }
+    CHECK(exited,
+          "exit_group: process exits despite running thread",
+          "timed out — spinning thread kept process alive");
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 55,
+          "exit_group: exit code 55 correct", "wrong exit code");
+}
+
+/* ================================================================== */
+/* 22. Raw SYS_exit on single-threaded child                           */
+/* ================================================================== */
+
+static void test_raw_exit_syscall(void)
+{
+    puts("\n[ 22. raw SYS_exit syscall ]");
+
+    pid_t child = fork();
+    if (child == 0) {
+        syscall(SYS_exit, 77);
+        _exit(99);   /* not reached */
+    }
+    int status = 0;
+    waitpid(child, &status, 0);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 77,
+          "raw SYS_exit: exit code 77 seen by parent", "wrong code");
+}
+
+/* ================================================================== */
+/* 23. SIGCHLD delivered to parent on child exit                        */
+/* ================================================================== */
+
+static volatile sig_atomic_t sigchld_fired;
+static void sigchld_h(int s) { (void)s; sigchld_fired = 1; }
+
+static void test_sigchld(void)
+{
+    puts("\n[ 23. SIGCHLD on child exit ]");
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = sigchld_h;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_NOCLDSTOP;
+    sigaction(SIGCHLD, &sa, NULL);
+
+    sigchld_fired = 0;
+    pid_t child = fork();
+    if (child == 0) _exit(0);
+
+    int res = waitpid(child, NULL, 0);
+    if (res != child) {
+	    printf("Waitpid returned %d\n", res);
+	    perror("23.");
+	    exit(1);
+    }
+    CHECK(sigchld_fired, "SIGCHLD delivered on child exit", "not delivered");
+
+    /* restore */
+    struct sigaction dfl;
+    memset(&dfl, 0, sizeof dfl);
+    dfl.sa_handler = SIG_DFL;
+    sigemptyset(&dfl.sa_mask);
+    sigaction(SIGCHLD, &dfl, NULL);
+}
+
+/* ================================================================== */
+/* 24. WIFSIGNALED — child killed by signal                            */
+/* ================================================================== */
+
+static void test_wifsignaled(void)
+{
+    puts("\n[ 24. WIFSIGNALED / WTERMSIG ]");
+
+    pid_t child = fork();
+    if (child == 0) {
+        /* restore default SIGUSR1 so it terminates us */
+        struct sigaction dfl;
+        memset(&dfl, 0, sizeof dfl);
+        dfl.sa_handler = SIG_DFL;
+        sigemptyset(&dfl.sa_mask);
+        sigaction(SIGUSR1, &dfl, NULL);
+        raise(SIGUSR1);
+        _exit(99);
+    }
+    int status = 0;
+    waitpid(child, &status, 0);
+    CHECK(WIFSIGNALED(status), "child terminated by signal", "not signaled");
+    CHECK(WTERMSIG(status) == SIGUSR1,
+          "WTERMSIG == SIGUSR1", "wrong signal");
+}
+
+/* ================================================================== */
+/* 25. exit_group vs exit: single extra thread stays if only           */
+/*    SYS_exit is called in a multi-threaded child                     */
+/*    (child exits only when last thread calls exit)                   */
+/* ================================================================== */
+
+static int eg_pipe[2];
+
+static void *eg_thread_fn(void *arg)
+{
+    (void)arg;
+    /* thread signals parent it started */
+    write(eg_pipe[1], "s", 1);
+    /* thread blocks, keeping the process alive */
+    char buf;
+    read(eg_pipe[0], &buf, 1);
+    /* thread exits cleanly */
+    syscall(SYS_exit, 0);
+    return NULL;
+}
+
+static void test_exit_only_one_thread(void)
+{
+    puts("\n[ 25. SYS_exit exits calling thread only ]");
+
+    pipe(eg_pipe);
+
+    pid_t child = fork();
+    if (child == 0) {
+        pthread_t t;
+        pthread_create(&t, NULL, eg_thread_fn, NULL);
+        /* wait until thread started */
+        char buf;
+        read(eg_pipe[0], &buf, 1);
+        /* exit this thread only — child process should still be alive
+           because the other thread is still running */
+        syscall(SYS_exit, 0);
+        _exit(99);  /* not reached */
+    }
+
+    /* parent reads the thread's "started" byte, then tells it to exit */
+    char buf;
+    read(eg_pipe[0], &buf, 1);   /* 's' from thread */
+
+    /* Give child a moment — it should NOT have exited yet */
+    usleep(30000);
+    int status = 0;
+    pid_t r = waitpid(child, &status, WNOHANG);
+    CHECK(r == 0,
+          "SYS_exit on one thread: process still alive (other thread running)",
+          "process exited prematurely");
+
+    /* now tell the surviving thread to exit too */
+    write(eg_pipe[1], "x", 1);
+    waitpid(child, &status, 0);
+
+    close(eg_pipe[0]);
+    close(eg_pipe[1]);
+}
+
+/* ================================================================== */
+/* 26. kill(getpid(), sig) delivers to self                            */
+/* ================================================================== */
+
+static volatile sig_atomic_t kill_self_fired;
+static void kill_self_h(int s) { (void)s; kill_self_fired = 1; }
+
+static void test_kill_self(void)
+{
+    puts("\n[ 26. kill(getpid()) delivers to self ]");
+    reset_usr();
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = kill_self_h;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR1, &sa, NULL);
+
+    kill_self_fired = 0;
+    kill(getpid(), SIGUSR1);
+    CHECK(kill_self_fired, "kill(getpid(), SIGUSR1) delivers signal", "not delivered");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 27. Signal disposition inherited by child after fork                */
+/* ================================================================== */
+
+static volatile sig_atomic_t fork_disp_fired;
+static void fork_disp_h(int s) { (void)s; fork_disp_fired = 1; }
+
+static void test_fork_disposition_inherit(void)
+{
+    puts("\n[ 27. fork: signal disposition inherited ]");
+    reset_usr();
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = fork_disp_h;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR1, &sa, NULL);
+
+    pid_t child = fork();
+    if (child == 0) {
+        fork_disp_fired = 0;
+        kill(getpid(), SIGUSR1);  /* raise() uses tgkill which is unregistered */
+        _exit(fork_disp_fired ? 1 : 0);
+    }
+
+    int status = 0;
+    waitpid(child, &status, 0);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 1,
+          "fork: child inherited SIGUSR1 handler", "handler not inherited");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 28. Signal mask inherited by child after fork                       */
+/* ================================================================== */
+
+static void test_fork_sigmask_inherit(void)
+{
+    puts("\n[ 28. fork: signal mask inherited ]");
+    reset_usr();
+
+    sigset_t blk;
+    sigemptyset(&blk);
+    sigaddset(&blk, SIGUSR1);
+    sigprocmask(SIG_BLOCK, &blk, NULL);
+
+    pid_t child = fork();
+    if (child == 0) {
+        sigset_t cur;
+        sigprocmask(SIG_BLOCK, NULL, &cur);
+        _exit(sigismember(&cur, SIGUSR1) ? 1 : 0);
+    }
+
+    sigprocmask(SIG_UNBLOCK, &blk, NULL);
+
+    int status = 0;
+    waitpid(child, &status, 0);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 1,
+          "fork: child inherited blocked SIGUSR1 mask", "mask not inherited");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 29. Signal delivery order: lower signal number first                */
+/* ================================================================== */
+
+static volatile sig_atomic_t ord_first;
+static volatile sig_atomic_t ord_second;
+
+static void ord_u1_h(int s)
+{
+    (void)s;
+    if (!ord_first) ord_first  = SIGUSR1;
+    else            ord_second = SIGUSR1;
+}
+static void ord_u2_h(int s)
+{
+    (void)s;
+    if (!ord_first) ord_first  = SIGUSR2;
+    else            ord_second = SIGUSR2;
+}
+
+static void test_signal_delivery_order(void)
+{
+    puts("\n[ 29. signal delivery order: lower signo first ]");
+    reset_usr();
+
+    struct sigaction sa1, sa2;
+    memset(&sa1, 0, sizeof sa1); sa1.sa_handler = ord_u1_h; sigemptyset(&sa1.sa_mask);
+    memset(&sa2, 0, sizeof sa2); sa2.sa_handler = ord_u2_h; sigemptyset(&sa2.sa_mask);
+    sigaction(SIGUSR1, &sa1, NULL);
+    sigaction(SIGUSR2, &sa2, NULL);
+
+    sigset_t blk;
+    sigemptyset(&blk);
+    sigaddset(&blk, SIGUSR1);
+    sigaddset(&blk, SIGUSR2);
+    sigprocmask(SIG_BLOCK, &blk, NULL);
+
+    ord_first = ord_second = 0;
+    raise(SIGUSR2);  /* raise higher number first */
+    raise(SIGUSR1);
+
+    sigprocmask(SIG_UNBLOCK, &blk, NULL);
+
+    CHECK(ord_first == SIGUSR1,
+          "SIGUSR1 (lower signo) delivered before SIGUSR2", "wrong delivery order");
+
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 30. sigtimedwait — signal already pending → immediate return        */
+/* ================================================================== */
+
+static void test_sigtimedwait_pending(void)
+{
+    puts("\n[ 30. sigtimedwait: signal already pending ]");
+    reset_usr();
+
+    /* block SIGUSR1 so raise() queues it without delivery */
+    sigset_t blk;
+    sigemptyset(&blk);
+    sigaddset(&blk, SIGUSR1);
+    sigprocmask(SIG_BLOCK, &blk, NULL);
+
+    raise(SIGUSR1);
+
+    siginfo_t info;
+    memset(&info, 0, sizeof info);
+    struct timespec ts = { .tv_sec = 5, .tv_nsec = 0 };
+    int ret = sigtimedwait(&blk, &info, &ts);
+
+    CHECK(ret == SIGUSR1, "sigtimedwait returns SIGUSR1", "wrong return value");
+    CHECK(info.si_signo == SIGUSR1, "si_signo == SIGUSR1", "wrong si_signo");
+
+    /* signal must have been consumed */
+    sigset_t pend;
+    sigpending(&pend);
+    CHECK(!sigismember(&pend, SIGUSR1),
+          "signal consumed by sigtimedwait", "still pending after sigtimedwait");
+
+    sigprocmask(SIG_UNBLOCK, &blk, NULL);
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 31. sigtimedwait — timeout expires (nothing pending)                */
+/* ================================================================== */
+
+static void test_sigtimedwait_timeout(void)
+{
+    puts("\n[ 31. sigtimedwait: timeout ]");
+    reset_usr();
+
+    sigset_t blk;
+    sigemptyset(&blk);
+    sigaddset(&blk, SIGUSR1);
+    sigprocmask(SIG_BLOCK, &blk, NULL);
+
+    /* 50 ms timeout, no signal pending */
+    struct timespec ts = { .tv_sec = 0, .tv_nsec = 50000000 };
+    int ret = sigtimedwait(&blk, NULL, &ts);
+    int saved = errno;
+
+    CHECK(ret == -1 && saved == EAGAIN,
+          "sigtimedwait times out → -1/EAGAIN", "wrong return or errno");
+
+    sigprocmask(SIG_UNBLOCK, &blk, NULL);
+    reset_usr();
+}
+
+/* ================================================================== */
+/* 32. SIGKILL / SIGSTOP silently dropped by sigprocmask               */
+/* ================================================================== */
+
+static void test_sigkill_not_blockable(void)
+{
+    puts("\n[ 32. SIGKILL/SIGSTOP: sigprocmask silently ignores ]");
+
+    sigset_t blk, cur;
+    sigemptyset(&blk);
+    sigaddset(&blk, SIGKILL);
+    sigaddset(&blk, SIGSTOP);
+
+    int r = sigprocmask(SIG_BLOCK, &blk, NULL);
+    CHECK(r == 0, "sigprocmask(SIG_BLOCK, {SIGKILL,SIGSTOP}) returns 0", "failed");
+
+    sigprocmask(SIG_BLOCK, NULL, &cur);
+    CHECK(!sigismember(&cur, SIGKILL), "SIGKILL not in mask", "SIGKILL in mask");
+    CHECK(!sigismember(&cur, SIGSTOP), "SIGSTOP not in mask", "SIGSTOP in mask");
+
+    sigprocmask(SIG_UNBLOCK, &blk, NULL);
+}
+
+/* ================================================================== */
+/* main                                                                 */
+/* ================================================================== */
+
+int main(void)
+{
+    puts("=== signal test suite ===");
+
+    install_tkill_exit_handler();
+
+    test_basic_sigaction();
+    test_sa_resethand();
+    test_sa_nodefer();
+    test_sa_siginfo();
+    test_sigprocmask_block();
+    test_sigpending();
+    test_sigreturn_mask_restore();
+    test_sa_mask();
+    test_signal_self_masked();
+    test_multiple_pending();
+    test_uncatchable();
+    test_sigprocmask_setmask();
+    test_sigsuspend();
+    test_nodefer_siginfo();
+    test_sig_ign();
+    test_exit_code();
+    test_raw_exit_syscall();
+    test_sigchld();
+    test_wifsignaled();
+    test_kill_self();
+    test_fork_disposition_inherit();
+    test_fork_sigmask_inherit();
+    test_signal_delivery_order();
+    test_sigtimedwait_pending();
+    test_sigtimedwait_timeout();
+    test_sigkill_not_blockable();
+
+    // THREAD RELATED
+    test_thread_masked_pending();
+    test_thread_sigmask_independent();
+    test_process_signal_to_unblocked_thread();
+    test_pthread_kill();
+    // test_exit_only_one_thread();
+    test_exit_group();
+
+    printf("\n=== %d passed, %d failed ===\n", g_passed, g_failed);
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/wait.c
+++ b/tests/wait.c
@@ -1,0 +1,906 @@
+/*
+ * wait / wait4 test suite (i386 Linux)
+ *
+ * Covers: waitpid by pid / -1 / 0 / -pgid, exit status, signal
+ * termination, WNOHANG, WUNTRACED, wait4 rusage, raw SYS_wait4,
+ * ECHILD and EINVAL error paths, SIGCHLD delivery on exit (siginfo,
+ * blocking, SIG_IGN auto-reap) and signal interruption of a blocked
+ * wait (EINTR vs SA_RESTART / kernel ERESTARTSYS).
+ *
+ * WCONTINUED is not implemented in KFS yet: its test is kept under
+ * "#if 0" below -- flip to "#if 1" once the kernel supports it.
+ *
+ * Build:
+ *   zig cc -target x86-linux-musl -static -o test_wait test_wait.c
+ */
+#define _GNU_SOURCE
+
+#include <signal.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <time.h>
+#include <sys/wait.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+
+/* x86 32-bit syscall numbers (in case sys/syscall.h is incomplete) */
+#ifndef SYS_exit
+#define SYS_exit       1
+#endif
+#ifndef SYS_wait4
+#define SYS_wait4      114
+#endif
+#ifndef SYS_exit_group
+#define SYS_exit_group 252
+#endif
+
+/* ------------------------------------------------------------------ */
+/* Result tracking                                                     */
+/* ------------------------------------------------------------------ */
+
+static int g_passed = 0;
+static int g_failed = 0;
+
+static void ok(const char *name)
+{
+    printf("  PASS  %s\n", name);
+    g_passed++;
+}
+
+static void nok(const char *name, const char *why)
+{
+    printf("  FAIL  %s  [%s]\n", name, why);
+    g_failed++;
+}
+
+#define CHECK(cond, name, why) \
+    do { if ((cond)) ok(name); else nok(name, why); } while (0)
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/* Child body that sits alive until killed. Uses a nanosleep loop
+ * rather than pause(): KFS does not implement SYS_pause. */
+static void child_hang(void)
+{
+	for (;;)
+		usleep(100000);
+}
+
+/* Signal bookkeeping shared by the SIGCHLD / EINTR tests. */
+static volatile sig_atomic_t g_sigchld_hits;
+static volatile sig_atomic_t g_sigchld_pid;
+static volatile sig_atomic_t g_sigchld_status;
+static volatile sig_atomic_t g_sigchld_code;
+static volatile sig_atomic_t g_sigusr1_hits;
+
+static void sigchld_info_handler(int sig, siginfo_t *si, void *ctx)
+{
+	(void)sig;
+	(void)ctx;
+	g_sigchld_hits++;
+	if (si) {
+		g_sigchld_pid = si->si_pid;
+		g_sigchld_status = si->si_status;
+		g_sigchld_code = si->si_code;
+	}
+}
+
+static void sigchld_simple_handler(int sig)
+{
+	(void)sig;
+	g_sigchld_hits++;
+}
+
+static void sigusr1_handler(int sig)
+{
+	(void)sig;
+	g_sigusr1_hits++;
+}
+
+/* Restore SIG_DFL and unblock, so tests do not leak dispositions. */
+static void reset_sig(int sig)
+{
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = SIG_DFL;
+	sigaction(sig, &sa, NULL);
+
+	sigset_t set;
+	sigemptyset(&set);
+	sigaddset(&set, sig);
+	sigprocmask(SIG_UNBLOCK, &set, NULL);
+}
+
+/* ------------------------------------------------------------------ */
+/* Which-child selection: pid, -1, 0, -pgid                            */
+/* ------------------------------------------------------------------ */
+
+static void test_basic_wait_by_pid(void)
+{
+	pid_t pid = fork();
+	if (pid == 0) {
+		exit(0);
+	}
+	int status;
+	int res = waitpid(pid, &status, 0);
+	CHECK(res == pid, "Child reaped successfully", "wait returned error");
+}
+
+static void test_basic_wait_any_child(void)
+{
+	pid_t pid1 = fork();
+	if (pid1 == 0) {
+		exit(0);
+	}
+
+	pid_t pid2 = fork();
+	if (pid2 == 0) {
+		exit(0);
+	}
+
+	int status;
+	int res = waitpid(-1, &status, 0);
+	CHECK(res == pid1 || res == pid2, "Wait -1 reaped one of two children",
+			"wait returned error");
+	res = waitpid(-1, &status, 0);
+	CHECK(res == pid1 || res == pid2, "Wait -1 reaped the last of two children",
+			"wait returned error");
+}
+
+static void test_basic_wait_any_child_with_pgid(void)
+{
+	pid_t pid1 = fork();
+	if (pid1 == 0) {
+		pid_t curr_pid = getpid();
+		setpgid(0, curr_pid);
+		exit(0);
+	}
+
+	pid_t pid2 = fork();
+	if (pid2 == 0) {
+		pid_t curr_pid = getpid();
+		setpgid(0, curr_pid);
+		exit(0);
+	}
+
+	usleep(20000);
+	int status;
+	int res = waitpid(-pid1, &status, 0);
+	CHECK(res == pid1, "Wait -pgid reaped correct child",
+			"wait returned error");
+	res = waitpid(-pid2, &status, 0);
+	CHECK(res == pid2, "Wait -pgid reaped correct child",
+			"wait returned error");
+}
+
+static void test_basic_wait_any_child_with_parent_pgid(void)
+{
+	pid_t pid1 = fork();
+	if (pid1 == 0) {
+		exit(0);
+	} else if (pid1 < 0) {
+		printf("Fork failed. Skipping...\n");
+		return;
+	}
+
+	pid_t pid2 = fork();
+	if (pid2 == 0) {
+		pid_t curr_pid = getpid();
+		setpgid(0, curr_pid);
+		exit(0);
+	} else if (pid2 < 0) {
+		printf("Fork failed. Skipping...\n");
+		return;
+	}
+
+	usleep(20000);
+	int status;
+	int res = waitpid(0, &status, 0);
+	CHECK(res == pid1, "Wait 0 reaped child in own process group",
+			"wait returned error");
+	errno = 0;
+	res = waitpid(0, &status, 0);
+	CHECK(res == -1 && errno == ECHILD, "Wait 0 returns ECHILD when group empty",
+			"wait reaped child outside own group");
+	res = waitpid(-pid2, &status, 0);
+	CHECK(res == pid2, "Wait -pgid reaped child that left our group",
+			"wait returned error");
+}
+
+/* ------------------------------------------------------------------ */
+/* Status decoding                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_exit_status(void)
+{
+	pid_t pid = fork();
+	if (pid == 0) {
+		exit(42);
+	}
+	int status = -1;
+	int res = waitpid(pid, &status, 0);
+	CHECK(res == pid, "Exit status: child reaped", "wait returned error");
+	CHECK(WIFEXITED(status), "Exit status: WIFEXITED set",
+			"not reported as normal exit");
+	CHECK(!WIFSIGNALED(status) && !WIFSTOPPED(status),
+			"Exit status: no signal/stop bits", "bogus status bits set");
+	CHECK(WEXITSTATUS(status) == 42, "Exit status: WEXITSTATUS == 42",
+			"wrong exit code");
+}
+
+static void run_signal_termination(int sig, const char *signame)
+{
+	char name[96];
+	pid_t pid = fork();
+	if (pid == 0) {
+		child_hang();
+	}
+	usleep(20000);
+	kill(pid, sig);
+	int status = -1;
+	int res = waitpid(pid, &status, 0);
+	snprintf(name, sizeof(name), "Killed by %s: child reaped", signame);
+	CHECK(res == pid, name, "wait returned error");
+	snprintf(name, sizeof(name), "Killed by %s: WIFSIGNALED + WTERMSIG", signame);
+	CHECK(WIFSIGNALED(status) && WTERMSIG(status) == sig, name,
+			"wrong termination status");
+	snprintf(name, sizeof(name), "Killed by %s: WIFEXITED clear", signame);
+	CHECK(!WIFEXITED(status), name, "reported as normal exit");
+}
+
+static void test_signal_termination(void)
+{
+	run_signal_termination(SIGKILL, "SIGKILL");
+	run_signal_termination(SIGTERM, "SIGTERM");
+}
+
+static void test_status_null(void)
+{
+	pid_t pid = fork();
+	if (pid == 0) {
+		exit(0);
+	}
+	int res = waitpid(pid, NULL, 0);
+	CHECK(res == pid, "NULL status pointer accepted", "wait returned error");
+}
+
+static void test_zombie_persists(void)
+{
+	pid_t pid = fork();
+	if (pid == 0) {
+		exit(5);
+	}
+	/* child is long dead by now; the zombie must still be reapable */
+	usleep(50000);
+	int status = -1;
+	int res = waitpid(pid, &status, 0);
+	CHECK(res == pid && WIFEXITED(status) && WEXITSTATUS(status) == 5,
+			"Zombie persists until reaped", "zombie lost or wrong status");
+}
+
+static void test_selective_wait_skips_other_zombie(void)
+{
+	pid_t zom = fork();
+	if (zom == 0) {
+		exit(1);
+	}
+	pid_t pid = fork();
+	if (pid == 0) {
+		usleep(50000);
+		exit(2);
+	}
+	/* zom becomes a zombie immediately; waiting for pid must block past it */
+	int status = -1;
+	int res = waitpid(pid, &status, 0);
+	CHECK(res == pid && WIFEXITED(status) && WEXITSTATUS(status) == 2,
+			"Selective wait: requested pid returned",
+			"reaped wrong child or wrong status");
+	res = waitpid(zom, &status, 0);
+	CHECK(res == zom && WIFEXITED(status) && WEXITSTATUS(status) == 1,
+			"Selective wait: earlier zombie still reapable",
+			"first zombie lost");
+}
+
+/* ------------------------------------------------------------------ */
+/* WNOHANG                                                             */
+/* ------------------------------------------------------------------ */
+
+static void test_wnohang(void)
+{
+	pid_t pid = fork();
+	if (pid == 0) {
+		usleep(100000);
+		exit(3);
+	}
+	int status = -1;
+	int res = waitpid(pid, &status, WNOHANG);
+	CHECK(res == 0, "WNOHANG: 0 while child is alive",
+			"returned before child exited");
+
+	pid_t got = 0;
+	for (int i = 0; i < 500 && got == 0; i++) {
+		usleep(10000);
+		got = waitpid(pid, &status, WNOHANG);
+	}
+	CHECK(got == pid && WIFEXITED(status) && WEXITSTATUS(status) == 3,
+			"WNOHANG: reaps zombie once child exits",
+			"polling never returned the child");
+}
+
+/* ------------------------------------------------------------------ */
+/* WUNTRACED (stopped children)                                        */
+/* ------------------------------------------------------------------ */
+
+static void test_wuntraced(void)
+{
+	pid_t pid = fork();
+	if (pid == 0) {
+		child_hang();
+	}
+	usleep(20000);
+	kill(pid, SIGSTOP);
+
+	int status = -1;
+	int res = waitpid(pid, &status, WUNTRACED);
+	CHECK(res == pid, "WUNTRACED: returns stopped child",
+			"wait returned error");
+	CHECK(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP,
+			"WUNTRACED: WIFSTOPPED + WSTOPSIG == SIGSTOP",
+			"wrong stop status");
+	CHECK(!WIFEXITED(status) && !WIFSIGNALED(status),
+			"WUNTRACED: exit/signal bits clear", "bogus status bits set");
+
+	/* the stop event is one-shot, and a merely-stopped child is not a
+	 * zombie: plain WNOHANG must see nothing */
+	res = waitpid(pid, &status, WNOHANG);
+	CHECK(res == 0, "WUNTRACED: stop reported only once",
+			"stopped child reported again / reaped");
+
+	kill(pid, SIGCONT);
+	usleep(20000);
+	kill(pid, SIGKILL);
+	res = waitpid(pid, &status, 0);
+	CHECK(res == pid && WIFSIGNALED(status) && WTERMSIG(status) == SIGKILL,
+			"WUNTRACED: continued child killed and reaped",
+			"could not reap child after SIGCONT");
+}
+
+/* ------------------------------------------------------------------ */
+/* wait4: rusage argument and raw syscall                              */
+/* ------------------------------------------------------------------ */
+
+static void test_wait4_rusage(void)
+{
+	pid_t pid = fork();
+	if (pid == 0) {
+		/* burn a little CPU so utime is nonzero on kernels that track it */
+		volatile unsigned long x = 0;
+		for (unsigned long i = 0; i < 3000000; i++)
+			x += i;
+		(void)x;
+		exit(7);
+	}
+
+	struct rusage ru;
+	memset(&ru, 0xaa, sizeof(ru));
+	int status = -1;
+	int res = wait4(pid, &status, 0, &ru);
+	CHECK(res == pid && WIFEXITED(status) && WEXITSTATUS(status) == 7,
+			"wait4: reaps child with rusage pointer",
+			"wait4 returned error or wrong status");
+
+	int wrote = 0;
+	const unsigned char *p = (const unsigned char *)&ru;
+	for (size_t i = 0; i < sizeof(ru); i++) {
+		if (p[i] != 0xaa)
+			wrote = 1;
+	}
+	CHECK(wrote, "wait4: rusage struct written by kernel",
+			"rusage left untouched");
+
+	/* NULL rusage must also be accepted */
+	pid = fork();
+	if (pid == 0) {
+		exit(0);
+	}
+	res = wait4(pid, &status, 0, NULL);
+	CHECK(res == pid, "wait4: NULL rusage accepted", "wait4 returned error");
+}
+
+#ifdef __linux__
+static void test_raw_sys_wait4(void)
+{
+	pid_t pid = fork();
+	if (pid == 0) {
+		syscall(SYS_exit_group, 9);
+	}
+	int status = -1;
+	long res = syscall(SYS_wait4, pid, &status, 0, NULL);
+	CHECK(res == pid, "SYS_wait4: raw syscall reaps child",
+			"syscall returned error");
+	CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 9,
+			"SYS_wait4: exit_group status propagated",
+			"wrong status word");
+}
+#endif
+
+/* ------------------------------------------------------------------ */
+/* SIGCHLD on child exit, and its interaction with a blocked wait     */
+/* ------------------------------------------------------------------ */
+
+static void test_sigchld_on_exit(void)
+{
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_sigaction = sigchld_info_handler;
+	sa.sa_flags = SA_SIGINFO;
+	sigemptyset(&sa.sa_mask);
+	sigaction(SIGCHLD, &sa, NULL);
+	g_sigchld_hits = 0;
+	g_sigchld_pid = g_sigchld_status = g_sigchld_code = -1;
+
+	pid_t pid = fork();
+	if (pid == 0) {
+		usleep(20000);
+		exit(12);
+	}
+	/* retry on EINTR: BSD kernels let the SIGCHLD interrupt the wait;
+	 * the no-EINTR Linux semantics get their own test below */
+	int status = -1;
+	int res;
+	do {
+		errno = 0;
+		res = waitpid(pid, &status, 0);
+	} while (res == -1 && errno == EINTR);
+	CHECK(res == pid && WIFEXITED(status) && WEXITSTATUS(status) == 12,
+			"SIGCHLD on exit: child reaped", "wait returned error");
+
+	/* the pending SIGCHLD is normally handled before waitpid returns
+	 * to us; give a slower kernel a moment anyway */
+	for (int i = 0; i < 100 && g_sigchld_hits == 0; i++)
+		usleep(10000);
+	CHECK(g_sigchld_hits == 1, "SIGCHLD on exit: delivered exactly once",
+			"missing or duplicate SIGCHLD");
+	CHECK(g_sigchld_pid == pid, "SIGCHLD on exit: si_pid is the child",
+			"wrong si_pid");
+	CHECK(g_sigchld_code == CLD_EXITED, "SIGCHLD on exit: si_code == CLD_EXITED",
+			"wrong si_code");
+	CHECK(g_sigchld_status == 12, "SIGCHLD on exit: si_status is exit code",
+			"wrong si_status");
+	reset_sig(SIGCHLD);
+}
+
+static void test_sigchld_pending_while_blocked(void)
+{
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = sigchld_simple_handler;
+	sigemptyset(&sa.sa_mask);
+	sigaction(SIGCHLD, &sa, NULL);
+	g_sigchld_hits = 0;
+
+	sigset_t set;
+	sigemptyset(&set);
+	sigaddset(&set, SIGCHLD);
+	sigprocmask(SIG_BLOCK, &set, NULL);
+
+	pid_t pid = fork();
+	if (pid == 0) {
+		exit(0);
+	}
+
+	/* let the child die while SIGCHLD is masked; check the pending
+	 * set BEFORE reaping (BSD kernels discard the pending SIGCHLD
+	 * when wait reaps the last child, Linux keeps it) */
+	usleep(100000);
+	CHECK(g_sigchld_hits == 0, "SIGCHLD blocked: handler not run while masked",
+			"handler ran despite mask");
+
+	sigset_t pend;
+	sigemptyset(&pend);
+	sigpending(&pend);
+	CHECK(sigismember(&pend, SIGCHLD) == 1,
+			"SIGCHLD blocked: shown in sigpending", "signal not pending");
+
+	sigprocmask(SIG_UNBLOCK, &set, NULL);
+	CHECK(g_sigchld_hits == 1, "SIGCHLD blocked: delivered on unblock",
+			"handler did not run on unblock");
+
+	int status;
+	int res = waitpid(pid, &status, 0);
+	CHECK(res == pid, "SIGCHLD blocked: child reapable after unblock",
+			"wait returned error");
+	reset_sig(SIGCHLD);
+}
+
+/* The child's exit both raises SIGCHLD and satisfies the wait: the
+ * wait must return the pid, not -1/EINTR, even though the SIGCHLD
+ * handler has no SA_RESTART. */
+static void test_sigchld_does_not_interrupt_wait(void)
+{
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = sigchld_simple_handler;
+	sa.sa_flags = 0;
+	sigemptyset(&sa.sa_mask);
+	sigaction(SIGCHLD, &sa, NULL);
+	g_sigchld_hits = 0;
+
+	pid_t pid = fork();
+	if (pid == 0) {
+		usleep(100000);
+		exit(4);
+	}
+	int status = -1;
+	errno = 0;
+	int res = waitpid(pid, &status, 0);
+	int saved_errno = errno;
+	CHECK(res == pid && WIFEXITED(status) && WEXITSTATUS(status) == 4,
+			"SIGCHLD vs wait: exit satisfies wait, no EINTR",
+			"wait returned EINTR instead of the child");
+	CHECK(g_sigchld_hits == 1, "SIGCHLD vs wait: handler still ran",
+			"SIGCHLD not delivered");
+	/* on kernels with the BSD behaviour the check above fails with
+	 * EINTR: still reap, or later tests inherit a zombie */
+	if (res == -1 && saved_errno == EINTR)
+		while (waitpid(pid, &status, 0) == -1 && errno == EINTR)
+			;
+	reset_sig(SIGCHLD);
+}
+
+/* An unrelated signal with no SA_RESTART must interrupt a blocked
+ * wait with EINTR (kernel returns ERESTARTSYS, no restart requested). */
+static void test_wait_eintr(void)
+{
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = sigusr1_handler;
+	sa.sa_flags = 0;
+	sigemptyset(&sa.sa_mask);
+	sigaction(SIGUSR1, &sa, NULL);
+	g_sigusr1_hits = 0;
+
+	pid_t slow = fork();
+	if (slow == 0) {
+		usleep(500000);
+		exit(0);
+	}
+	pid_t signaler = fork();
+	if (signaler == 0) {
+		usleep(50000);
+		kill(getppid(), SIGUSR1);
+		exit(0);
+	}
+
+	int status;
+	errno = 0;
+	int res = waitpid(slow, &status, 0);
+	CHECK(res == -1 && errno == EINTR,
+			"EINTR: signal without SA_RESTART interrupts wait",
+			"wait was not interrupted");
+	CHECK(g_sigusr1_hits == 1, "EINTR: handler ran before wait returned",
+			"handler did not run");
+
+	res = waitpid(slow, &status, 0);
+	CHECK(res == slow, "EINTR: re-issued wait reaps the child",
+			"wait returned error");
+	waitpid(signaler, &status, 0);
+	reset_sig(SIGUSR1);
+}
+
+/* With SA_RESTART the kernel's ERESTARTSYS handling must transparently
+ * restart the wait: the caller never sees EINTR and still gets the
+ * child's real status. */
+static void test_wait_sa_restart(void)
+{
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = sigusr1_handler;
+	sa.sa_flags = SA_RESTART;
+	sigemptyset(&sa.sa_mask);
+	sigaction(SIGUSR1, &sa, NULL);
+	g_sigusr1_hits = 0;
+
+	pid_t slow = fork();
+	if (slow == 0) {
+		usleep(500000);
+		exit(21);
+	}
+	pid_t signaler = fork();
+	if (signaler == 0) {
+		usleep(50000);
+		kill(getppid(), SIGUSR1);
+		exit(0);
+	}
+
+	int status = -1;
+	int res = waitpid(slow, &status, 0);
+	CHECK(res == slow && WIFEXITED(status) && WEXITSTATUS(status) == 21,
+			"SA_RESTART: wait restarted, child reaped with status",
+			"wait returned early or with error");
+	CHECK(g_sigusr1_hits == 1, "SA_RESTART: handler ran during wait",
+			"signal was never delivered");
+	waitpid(signaler, &status, 0);
+	reset_sig(SIGUSR1);
+}
+
+/* POSIX: with SIGCHLD set to SIG_IGN children are auto-reaped; a
+ * blocking wait sleeps until every child is gone, then fails ECHILD. */
+static void test_sigchld_ignored_autoreap(void)
+{
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = SIG_IGN;
+	sigaction(SIGCHLD, &sa, NULL);
+
+	pid_t pid = fork();
+	if (pid == 0) {
+		usleep(50000);
+		exit(0);
+	}
+	/* poll with WNOHANG (bounded) instead of a blocking wait, so a
+	 * kernel that never auto-reaps fails instead of hanging us:
+	 * 0 while the child lives, then ECHILD once it is auto-reaped;
+	 * returning the pid means no auto-reap happened */
+	int status;
+	int res = 0;
+	errno = 0;
+	for (int i = 0; i < 300 && res == 0; i++) {
+		usleep(10000);
+		errno = 0;
+		res = waitpid(pid, &status, WNOHANG);
+	}
+	CHECK(res == -1 && errno == ECHILD,
+			"SIG_IGN: child auto-reaped, wait gets ECHILD",
+			"child was not auto-reaped");
+	reset_sig(SIGCHLD);
+}
+
+/* SA_NOCLDWAIT with a real handler: same auto-reap semantics as
+ * SIG_IGN, but Linux still delivers SIGCHLD to the handler. */
+static void test_sa_nocldwait(void)
+{
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = sigchld_simple_handler;
+	sa.sa_flags = SA_NOCLDWAIT;
+	sigemptyset(&sa.sa_mask);
+	printf("Sigaction\n");
+	sleep(5);
+	sigaction(SIGCHLD, &sa, NULL);
+	g_sigchld_hits = 0;
+
+	sleep(5);
+	printf("Fork\n");
+	pid_t pid = fork();
+	if (pid == 0) {
+		usleep(50000);
+		printf("Child exit\n");
+		exit(0);
+	}
+	/* bounded WNOHANG poll, same reasoning as the SIG_IGN test */
+	int status;
+	int res = 0;
+	errno = 0;
+	for (int i = 0; i < 300 && res == 0; i++) {
+		usleep(10000);
+		errno = 0;
+		printf("Wait\n");
+		res = waitpid(pid, &status, WNOHANG);
+	}
+	CHECK(res == -1 && errno == ECHILD,
+			"SA_NOCLDWAIT: child auto-reaped, wait gets ECHILD",
+			"child was not auto-reaped");
+	for (int i = 0; i < 100 && g_sigchld_hits == 0; i++)
+		usleep(10000);
+	CHECK(g_sigchld_hits == 1, "SA_NOCLDWAIT: SIGCHLD still delivered",
+			"handler did not run");
+	sleep(100);
+	reset_sig(SIGCHLD);
+}
+
+/* ------------------------------------------------------------------ */
+/* Error paths                                                         */
+/* ------------------------------------------------------------------ */
+
+/* Must run with no outstanding children. */
+static void test_echild(void)
+{
+	int status;
+	errno = 0;
+	int res = waitpid(-1, &status, 0);
+	CHECK(res == -1 && errno == ECHILD, "ECHILD: no children at all",
+			"expected -1/ECHILD");
+
+	errno = 0;
+	res = waitpid(1, &status, 0);
+	CHECK(res == -1 && errno == ECHILD, "ECHILD: pid 1 is not our child",
+			"expected -1/ECHILD");
+
+	/* WNOHANG with no children is ECHILD, not 0 */
+	errno = 0;
+	res = waitpid(-1, &status, WNOHANG);
+	CHECK(res == -1 && errno == ECHILD, "ECHILD: WNOHANG with no children",
+			"expected -1/ECHILD");
+}
+
+static void test_einval_options(void)
+{
+	int status;
+	errno = 0;
+	/* 0x01000000 is not a valid wait4 option bit */
+	int res = waitpid(-1, &status, 0x01000000);
+	CHECK(res == -1 && errno == EINVAL, "EINVAL: invalid options bit",
+			"expected -1/EINVAL");
+}
+
+/* ------------------------------------------------------------------ */
+/* WCONTINUED -- not implemented in KFS yet, kept disabled             */
+/* ------------------------------------------------------------------ */
+
+#if 0 /* flip to 1 once the kernel implements WCONTINUED */
+static void test_wcontinued(void)
+{
+	pid_t pid = fork();
+	if (pid == 0) {
+		child_hang();
+	}
+	usleep(20000);
+	kill(pid, SIGSTOP);
+
+	int status = -1;
+	int res = waitpid(pid, &status, WUNTRACED);
+	CHECK(res == pid && WIFSTOPPED(status),
+			"WCONTINUED: child stopped first", "stop not reported");
+
+	kill(pid, SIGCONT);
+	res = waitpid(pid, &status, WCONTINUED);
+	CHECK(res == pid, "WCONTINUED: returns continued child",
+			"wait returned error");
+	CHECK(WIFCONTINUED(status), "WCONTINUED: WIFCONTINUED set",
+			"wrong status word");
+
+	/* the continue event is one-shot */
+	res = waitpid(pid, &status, WCONTINUED | WNOHANG);
+	CHECK(res == 0, "WCONTINUED: event reported only once",
+			"continue reported twice");
+
+	kill(pid, SIGKILL);
+	waitpid(pid, &status, 0);
+}
+#endif
+
+/* ------------------------------------------------------------------ */
+/* Watchdog runner: each test runs in its own forked process so a     */
+/* kernel bug in a blocking wait path FAILs after a timeout instead   */
+/* of hanging the whole suite. Also isolates zombies and signal       */
+/* dispositions between tests.                                        */
+/* ------------------------------------------------------------------ */
+
+#define TEST_TIMEOUT_TICKS 100 /* x 100ms = 10s per test */
+
+struct test {
+	const char *name;
+	void (*fn)(void);
+};
+
+static void run_test(const struct test *t)
+{
+	int pfd[2];
+	if (pipe(pfd) != 0) {
+		/* no pipe: run inline, accepting the hang risk */
+		t->fn();
+		return;
+	}
+
+	pid_t pid = fork();
+	if (pid < 0) {
+		printf("  FAIL  %s  [fork failed]\n", t->name);
+		g_failed++;
+		close(pfd[0]);
+		close(pfd[1]);
+		return;
+	}
+	if (pid == 0) {
+		close(pfd[0]);
+		setpgid(0, 0); /* own group, so the parent can kill the subtree */
+		g_passed = 0;
+		g_failed = 0;
+		t->fn();
+		char buf[32];
+		int n = snprintf(buf, sizeof(buf), "%d %d", g_passed, g_failed);
+		write(pfd[1], buf, n);
+		exit(0);
+	}
+	close(pfd[1]);
+
+	int status;
+	pid_t res = 0;
+	for (int i = 0; i < TEST_TIMEOUT_TICKS && res == 0; i++) {
+		usleep(100000);
+		res = waitpid(pid, &status, WNOHANG);
+	}
+
+	if (res == 0) {
+		printf("  FAIL  %s  [timeout after 10s, killing]\n", t->name);
+		g_failed++;
+		kill(-pid, SIGKILL); /* whole group, if the kernel supports it */
+		kill(pid, SIGKILL);
+		for (int i = 0; i < 20 && res == 0; i++) {
+			usleep(100000);
+			res = waitpid(pid, &status, WNOHANG);
+		}
+		if (res == 0)
+			printf("  WARN  %s: test process unkillable, leaking it\n",
+					t->name);
+		close(pfd[0]);
+		return;
+	}
+
+	char buf[32];
+	int n = read(pfd[0], buf, sizeof(buf) - 1);
+	close(pfd[0]);
+	int p = 0, f = 0;
+	if (n > 0) {
+		buf[n] = '\0';
+		sscanf(buf, "%d %d", &p, &f);
+		g_passed += p;
+		g_failed += f;
+	} else {
+		printf("  FAIL  %s  [test process died without reporting]\n",
+				t->name);
+		g_failed++;
+	}
+}
+
+#define TEST(fn) { #fn, fn }
+
+static const struct test g_tests[] = {
+	TEST(test_basic_wait_by_pid),
+	TEST(test_basic_wait_any_child),
+	TEST(test_basic_wait_any_child_with_pgid),
+	TEST(test_basic_wait_any_child_with_parent_pgid),
+	TEST(test_exit_status),
+	TEST(test_signal_termination),
+	TEST(test_status_null),
+	TEST(test_zombie_persists),
+	TEST(test_selective_wait_skips_other_zombie),
+	TEST(test_wnohang),
+	// TEST(test_wuntraced),
+	TEST(test_wait4_rusage),
+#ifdef __linux__
+	TEST(test_raw_sys_wait4),
+#endif
+	TEST(test_sigchld_on_exit),
+	TEST(test_sigchld_pending_while_blocked),
+	TEST(test_sigchld_does_not_interrupt_wait),
+	TEST(test_wait_eintr),
+	TEST(test_wait_sa_restart),
+	TEST(test_sigchld_ignored_autoreap),
+	TEST(test_sa_nocldwait),
+	TEST(test_echild),
+	TEST(test_einval_options),
+	/* TEST(test_wcontinued),  -- WCONTINUED not implemented in KFS yet */
+};
+
+int main(void)
+{
+    /* children exit via exit() and would re-flush inherited stdio
+     * buffers, duplicating output when stdout is not a tty */
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    puts("=== wait test suite ===");
+
+    for (size_t i = 0; i < sizeof(g_tests) / sizeof(g_tests[0]); i++) {
+        run_test(&g_tests[i]);
+	sleep(1);
+    }
+
+    printf("\n=== %d passed, %d failed ===\n", g_passed, g_failed);
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
- Defer freeing to process context. Now we can call `(k|v)free` in any context.
- Move `mm.ref.put()` to processTasks (process Context) since in finish we have task lock taken and any other cpu that wants to schedule might deadlock on us waiting for ACK with the lock taken.