### PR TITLE
Make smp tests pass on KFS

### DIFF
--- a/src/arch/x86/mm/vmm.zig
+++ b/src/arch/x86/mm/vmm.zig
@@ -511,7 +511,7 @@ pub const VMM = struct {
                     invalidatePage(
                         self.pageTableToAddr(pd_idx, pt_idx),
                     );
-                    flushTLB(vma.mm.?.cpus_cores);
+                    flushTLB(vma.mm.?.cpuMask());
                     self.pmm.freePage(phys);
                 }
             }
@@ -520,7 +520,7 @@ pub const VMM = struct {
                 invalidatePage(
                     self.pageTableToAddr(pd_idx, 0)
                 );
-                flushTLB(vma.mm.?.cpus_cores);
+                flushTLB(vma.mm.?.cpuMask());
                 self.pmm.freePage((pd[pd_idx] >> 12) << 12);
             }
 

--- a/src/kernel/mm/proc_mm.zig
+++ b/src/kernel/mm/proc_mm.zig
@@ -222,7 +222,7 @@ pub const MM = struct {
     vas: usize = 0,
     lock: krn.Spinlock = krn.Spinlock.init(),
     vmas: ?*VMA = null,
-    cpus_cores: std.bit_set.IntegerBitSet(32) = std.bit_set.IntegerBitSet(32).initEmpty(),
+    cpus_cores: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
     ref: krn.RefCount = krn.RefCount.init(),
 
     pub fn init() MM {
@@ -232,7 +232,7 @@ pub const MM = struct {
             .stack_top = STACK_TOP,
             .stack_bottom = STACK_BOTTOM,
             .vmas = null,
-            .cpus_cores = std.bit_set.IntegerBitSet(32).initEmpty(),
+            .cpus_cores = std.atomic.Value(u32).init(0),
         };
         _mm.ref.get();
         _mm.ref.dropFn = MM.release;
@@ -597,17 +597,15 @@ pub const MM = struct {
     }
 
     pub fn setCPU(self: *MM, cpuid: u32) void {
-        self.lock.lock();
-        defer self.lock.unlock();
-
-        self.cpus_cores.set(cpuid);
+        _ = self.cpus_cores.bitSet(@intCast(cpuid), .seq_cst);
     }
 
     pub fn unsetCPU(self: *MM, cpuid: u32) void {
-        self.lock.lock();
-        defer self.lock.unlock();
+        _ = self.cpus_cores.bitReset(@intCast(cpuid), .seq_cst);
+    }
 
-        self.cpus_cores.unset(cpuid);
+    pub fn cpuMask(self: *MM) std.bit_set.IntegerBitSet(32) {
+        return .{ .mask = self.cpus_cores.load(.seq_cst) };
     }
 };
 

--- a/src/kernel/sched/scheduler.zig
+++ b/src/kernel/sched/scheduler.zig
@@ -98,10 +98,8 @@ fn findNextTask() *tsk.Task {
 }
 
 pub fn schedule() void {
-    if (!isPreemtionEnabled()) {
-        krn.logger.INFO("cpu {d} preemted: {d}", .{arch.smp.logical_id.get(), preemtion_enabled.get()});
+    if (!isPreemtionEnabled())
         return ;
-    }
     const flags = arch.cpu.saveFlagsAndCli();
     defer arch.cpu.restoreFlags(flags);
     const prev = tsk.current();

--- a/src/kernel/userspace/userspace.zig
+++ b/src/kernel/userspace/userspace.zig
@@ -57,12 +57,14 @@ const AuxEntry = struct {
 };
 
 const AT_NULL = 0;
-const AT_PHDR = 3;  // address of program headers in memory
-const AT_PHENT = 4; // size of one program header
-const AT_PHNUM = 5; // number of program headers
+const AT_PHDR = 3;      // address of program headers in memory
+const AT_PHENT = 4;     // size of one program header
+const AT_PHNUM = 5;     // number of program headers
 const AT_PAGESZ = 6;
-const AT_BASE = 7;  // load base for PIE
-const AT_ENTRY = 9; // entry point address
+const AT_BASE = 7;      // load base for PIE
+const AT_ENTRY = 9;     // entry point address
+const AT_HWCAP = 16;    // Musl check AT_HWCAP for ldmxcsr
+// https://elixir.bootlin.com/musl/v1.2.6/source/src/fenv/i386/fenv.s#L1
 const AT_SYSINFO_EHDR = 33; // vDSO ELF header address
 
 const vdso = @import("../vdso.zig");
@@ -363,6 +365,11 @@ pub fn prepareBinary(
     aux_buf[aux_count] = .{ .key = AT_SYSINFO_EHDR, .val = vdso_ehdr_addr };
     aux_count += 1;
     aux_buf[aux_count] = .{ .key = AT_PAGESZ, .val = krn.mm.PAGE_SIZE };
+    aux_count += 1;
+    aux_buf[aux_count] = .{
+        .key = AT_HWCAP,
+        .val = @as(u32, @bitCast(arch.cpuid.info.features.edx)),
+    };
     aux_count += 1;
     aux_buf[aux_count] = .{ .key = AT_NULL, .val = 0 };
     aux_count += 1;

--- a/tests/smp.c
+++ b/tests/smp.c
@@ -603,6 +603,25 @@ static int test_tlb_shootdown(void)
     unsigned stable_cpu_count = 0;
     unsigned i;
 
+    reset_cpu_seen();
+    atomic_store(&tlb_phase, 0);
+    atomic_store(&tlb_ready, 0);
+    atomic_store(&tlb_initial_errors, 0);
+    memset(tlb_seen, 0, sizeof(tlb_seen));
+    memset(tlb_cpu_before, 0, sizeof(tlb_cpu_before));
+    memset(tlb_cpu_after, 0, sizeof(tlb_cpu_after));
+
+    /*
+     * Create the workers before mapping the test region otherwise the test
+     * might fail with exit code 11 due to trying to unmap regions where thread
+     * stacks live.
+     */
+    for (i = 0; i < TLB_WORKERS; i++) {
+        if (pthread_create(&threads[i], NULL, tlb_worker,
+                           (void *)(uintptr_t)i) != 0)
+            return failf("could not create TLB worker %u", i);
+    }
+
     region = mmap(NULL, 3 * TEST_PAGE_SIZE, PROT_READ | PROT_WRITE,
                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (region == MAP_FAILED)
@@ -618,18 +637,6 @@ static int test_tlb_shootdown(void)
     if (munmap(region + 2 * TEST_PAGE_SIZE, TEST_PAGE_SIZE) != 0)
         return failf("could not make remap guard hole: %s", strerror(errno));
 
-    reset_cpu_seen();
-    atomic_store(&tlb_phase, 0);
-    atomic_store(&tlb_ready, 0);
-    atomic_store(&tlb_initial_errors, 0);
-    memset(tlb_seen, 0, sizeof(tlb_seen));
-    memset(tlb_cpu_before, 0, sizeof(tlb_cpu_before));
-    memset(tlb_cpu_after, 0, sizeof(tlb_cpu_after));
-    for (i = 0; i < TLB_WORKERS; i++) {
-        if (pthread_create(&threads[i], NULL, tlb_worker,
-                           (void *)(uintptr_t)i) != 0)
-            return failf("could not create TLB worker %u", i);
-    }
     atomic_store_explicit(&tlb_phase, 1, memory_order_release);
     while (atomic_load_explicit(&tlb_ready, memory_order_acquire) !=
            TLB_WORKERS)

--- a/types/types.zig
+++ b/types/types.zig
@@ -816,7 +816,7 @@ pub const kernel = struct {
                 vas : u32= 0,
                 lock : kernel.Spinlock,
                 vmas : ?*kernel.mm.proc_mm.VMA= null,
-                cpus_cores : std.bit_set.IntegerBitSet(32),
+                cpus_cores : std.atomic.Value(u32),
                 ref : kernel.RefCount,
             };
 


### PR DESCRIPTION
- Convert cpu_cores to atomic bitset
- Add AT_HWCAP to aux vector entries
- Rearrange tlb invalidation test